### PR TITLE
Add ALP Stage 6 QA-to-Red executable tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/modules/ALP/05-qa-to-red/qa-catalog-alignment.md
+++ b/modules/ALP/05-qa-to-red/qa-catalog-alignment.md
@@ -1,0 +1,39 @@
+# APGI Learning Portal — QA Catalog Alignment
+
+## Status
+
+| Field | Value |
+|---|---|
+| Module | ALP — APGI Learning Portal |
+| Stage | 6 — QA-to-Red |
+| Version | 0.1 |
+| Status | Draft — module-local QA range reserved |
+| Build Authorized? | No |
+| PBFAG Authorized? | No |
+
+## Reserved QA Range
+
+```text
+QA-ALP-001 through QA-ALP-700
+```
+
+## Range Allocation
+
+| Range | Domain | Test File |
+|---|---|---|
+| QA-ALP-001 to QA-ALP-020 | Governance and artifact gates | governance-artifacts.spec.ts |
+| QA-ALP-021 to QA-ALP-065 | Architecture physical inventory | architecture-inventory.spec.ts |
+| QA-ALP-066 to QA-ALP-080 | Auth, roles, route protection | auth.spec.ts |
+| QA-ALP-211 to QA-ALP-250 | Course shell and unit viewer | course-shell.spec.ts |
+| QA-ALP-291 to QA-ALP-340 | Assessment submission | assessment-submission.spec.ts |
+| QA-ALP-416 to QA-ALP-450 | Certificates | certificate.spec.ts |
+| QA-ALP-526 to QA-ALP-565 | Security/privacy/RLS | security-privacy.spec.ts |
+| QA-ALP-636 to QA-ALP-700 | Deployment and CWT | deployment-cwt.spec.ts |
+
+## Alignment Statement
+
+This QA range is derived from App Description, UX Workflow & Wiring Spec, FRS, TRS, and Architecture v0.2. The range remains module-local until the Foreman/Governance Administrator either registers it in the canonical QA Catalog or formally accepts this module-local QA catalog for ALP.
+
+## Gate
+
+PBFAG remains blocked until executable RED proof is filed.

--- a/modules/ALP/05-qa-to-red/qa-to-red.md
+++ b/modules/ALP/05-qa-to-red/qa-to-red.md
@@ -1,0 +1,72 @@
+# APGI Learning Portal — Stage 6 QA-to-Red Specification
+
+## Status
+
+| Field | Value |
+|---|---|
+| Module | ALP — APGI Learning Portal |
+| Stage | 6 — QA-to-Red |
+| Version | 0.1 |
+| Status | Draft — executable RED tests added; RED proof still required |
+| Repository | APGI-cmy/Training |
+| Canonical Path | modules/ALP/05-qa-to-red/qa-to-red.md |
+| Build Authorized? | No |
+| PBFAG Authorized? | No |
+
+## Purpose
+
+This artifact defines the authoritative RED QA baseline for ALP. It is derived from the Stage 1–5 chain:
+
+```text
+App Description → UX Workflow & Wiring Spec → FRS → TRS → Architecture v0.2 → QA-to-Red
+```
+
+The tests are intended to fail before implementation because the required LMS routes, components, server actions, migrations, RLS policies, integrations, evidence files, and CWT proof do not yet exist.
+
+## Required RED Test Files
+
+```text
+tests/qa-to-red/alp/governance-artifacts.spec.ts
+tests/qa-to-red/alp/architecture-inventory.spec.ts
+tests/qa-to-red/alp/auth.spec.ts
+tests/qa-to-red/alp/course-shell.spec.ts
+tests/qa-to-red/alp/assessment-submission.spec.ts
+tests/qa-to-red/alp/certificate.spec.ts
+tests/qa-to-red/alp/security-privacy.spec.ts
+tests/qa-to-red/alp/deployment-cwt.spec.ts
+```
+
+## QA Domains
+
+| Domain | Coverage |
+|---|---|
+| Governance artifacts | App Description, UX, FRS, TRS, Architecture, QA-to-Red, registry |
+| Architecture inventory | Routes, components, server actions, migrations, env vars |
+| Auth/security | protected routes, server-side auth, no secret leaks |
+| Course shell | learner dashboard/course shell/unit viewer/progress hooks |
+| Assessment | submissions, evidence files, AI gateway, review state |
+| Certificates | eligibility, generation, download, audit |
+| RLS/privacy | table RLS, cross-learner denial, private files |
+| Deployment/CWT | build/typecheck/test scripts, evidence, CWT closure |
+
+## RED Validity Rule
+
+Valid RED means tests execute and fail because implementation artifacts are missing or incomplete. Invalid RED includes broken test runner setup, TypeScript syntax errors, skipped tests, or fake placeholder assertions.
+
+## Stage Gate
+
+Stage 6 is not complete until:
+
+- executable tests exist;
+- `npm run test:alp:red` executes;
+- failures are confirmed correct RED;
+- `red-proof-report.md` is completed;
+- QA Catalog alignment is accepted;
+- no implementation has started;
+- build remains blocked.
+
+## Next Artifact
+
+```text
+modules/ALP/05-qa-to-red/red-proof-report.md
+```

--- a/modules/ALP/05-qa-to-red/red-proof-report.md
+++ b/modules/ALP/05-qa-to-red/red-proof-report.md
@@ -1,0 +1,106 @@
+# APGI Learning Portal - RED Proof Report
+
+## Status
+
+Module: ALP - APGI Learning Portal
+Stage: 6 - QA-to-Red
+Version: 0.1
+Status: RED proof captured from local execution
+Branch: alp/stage-6-red-tests
+Command: npm run test:alp:red
+Executed by: Johan Ras
+Build Authorized: No
+PBFAG Authorized: No
+
+## Result Summary
+
+The Stage 6 RED suite executed successfully through Vitest.
+
+Observed result:
+
+- Test files executed: 8
+- Test files failed: 8
+- Total tests: 87
+- Failed tests: 81
+- Passed tests: 6
+- Duration: approximately 1.20s
+
+## RED Validity Finding
+
+This is a valid RED result for Stage 6 because:
+
+- npm install completed successfully.
+- Vitest started successfully.
+- Test files compiled and executed.
+- Failures are assertion failures for missing required ALP files and architecture artifacts.
+- Failures are not caused by malformed imports or a broken test runner.
+- The passing tests confirm some Stage 6 scaffolding exists, including the QA-to-Red specification, QA Catalog alignment, build script, typecheck script, and existing not-found route.
+
+## Representative Correct RED Failures
+
+The following failures are expected before ALP implementation:
+
+- Missing governance artifacts:
+  - modules/ALP/00-app-description/app-description.md
+  - modules/ALP/01-ux-workflow-wiring/ux-workflow-wiring-spec.md
+  - modules/ALP/02-frs/functional-requirements.md
+  - modules/ALP/03-trs/technical-requirements-specification.md
+  - modules/ALP/04-architecture/architecture.md
+  - modules/ALP/REQUIREMENT_REGISTRY.md
+
+- Missing ALP route files:
+  - app/(public)/login/page.tsx
+  - app/(learner)/dashboard/page.tsx
+  - app/(learner)/learn/[courseSlug]/page.tsx
+  - app/(admin)/admin/assessments/page.tsx
+  - app/(admin)/admin/reviews/page.tsx
+  - app/(learner)/certificates/page.tsx
+
+- Missing ALP components:
+  - components/auth/protected-layout.tsx
+  - components/auth/login-form.tsx
+  - components/course/course-sidebar.tsx
+  - components/course/unit-viewer.tsx
+  - components/certificates/certificate-viewer.tsx
+
+- Missing ALP server actions and services:
+  - server/actions/assessments/submit-assessment.ts
+  - server/actions/ai/evaluate-assessment-via-aimc.ts
+  - server/actions/reviews/review-assessment.ts
+  - server/actions/certificates/generate-certificate.ts
+  - lib/services/audit/write-audit-log.ts
+
+- Missing ALP database and environment artifacts:
+  - supabase/migrations/001_alp_auth_profile.sql
+  - supabase/migrations/007_alp_rls_policies.sql
+  - .env.example
+  - lib/config/env.ts
+
+- Missing final deployment/CWT proof:
+  - architecture/builds/ALP_BUILD_001_DRAFT/CWT_CLOSURE_REPORT.md
+
+## Passing Tests Observed
+
+The local run also showed passing tests for items that are already present in this Stage 6 PR:
+
+- QA-to-Red specification exists.
+- Build remains blocked in QA-to-Red.
+- QA Catalog alignment exists.
+- package.json build script exists.
+- package.json typecheck script exists.
+- app/not-found.tsx exists.
+
+## Decision
+
+Stage 6 executable RED proof is established for PR #46.
+
+The result is intentionally RED and suitable for the next governance review step, subject to final Foreman/Governance acceptance.
+
+## Gate Status
+
+PBFAG remains blocked until this RED proof is reviewed and accepted.
+Build remains blocked.
+
+## Next Step
+
+Review PR #46, accept this RED proof, then proceed to Stage 7 PBFAG only after confirming the Stage 6 PR is merged or otherwise canonically filed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "@types/node": "25.9.1",
         "@types/react": "19.2.15",
         "@types/react-dom": "19.2.3",
-        "typescript": "6.0.3"
+        "typescript": "6.0.3",
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -30,6 +31,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@img/colour": {
@@ -498,6 +941,13 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@next/env": {
       "version": "16.2.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
@@ -632,6 +1082,356 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -640,6 +1440,31 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.9.1",
@@ -671,6 +1496,131 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.32",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
@@ -681,6 +1631,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/caniuse-lite": {
@@ -703,6 +1663,33 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -716,6 +1703,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -725,6 +1740,139 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -797,11 +1945,41 @@
         }
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.15",
@@ -850,6 +2028,51 @@
       },
       "peerDependencies": {
         "react": "^19.2.6"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/scheduler": {
@@ -916,6 +2139,13 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -923,6 +2153,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/styled-jsx": {
@@ -946,6 +2203,67 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -974,6 +2292,194 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:alp:red": "vitest run tests/qa-to-red/alp",
+    "test:alp:red:static": "vitest run tests/qa-to-red/alp/governance-artifacts.spec.ts tests/qa-to-red/alp/architecture-inventory.spec.ts",
+    "test:alp:red:integration": "vitest run tests/qa-to-red/alp --exclude tests/qa-to-red/alp/deployment-cwt.spec.ts",
+    "test:alp:red:e2e": "vitest run tests/qa-to-red/alp/course-shell.spec.ts tests/qa-to-red/alp/assessment-submission.spec.ts tests/qa-to-red/alp/certificate.spec.ts",
+    "test:alp:red:cwt": "vitest run tests/qa-to-red/alp/deployment-cwt.spec.ts"
   },
   "dependencies": {
     "next": "16.2.6",
@@ -21,7 +26,8 @@
     "@types/node": "25.9.1",
     "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "^3.0.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/tests/qa-to-red/alp/architecture-inventory.spec.ts
+++ b/tests/qa-to-red/alp/architecture-inventory.spec.ts
@@ -29,33 +29,33 @@ const routes = [
 ];
 
 const components = [
-  "components/layout/app-shell.tsx",
-  "components/auth/protected-layout.tsx",
-  "components/auth/login-form.tsx",
-  "components/dashboard/learner-dashboard.tsx",
-  "components/course/course-shell.tsx",
-  "components/course/course-sidebar.tsx",
-  "components/course/unit-viewer.tsx",
-  "components/progress/progress-indicator.tsx",
-  "components/assessments/assessment-submission-form.tsx",
-  "components/reviews/review-queue.tsx",
-  "components/certificates/certificate-viewer.tsx",
-  "components/admin/admin-table.tsx",
-  "components/audit/audit-log-table.tsx"
+  "src/components/layout/app-shell.tsx",
+  "src/components/auth/protected-layout.tsx",
+  "src/components/auth/login-form.tsx",
+  "src/components/dashboard/learner-dashboard.tsx",
+  "src/components/course/course-shell.tsx",
+  "src/components/course/course-sidebar.tsx",
+  "src/components/course/unit-viewer.tsx",
+  "src/components/progress/progress-indicator.tsx",
+  "src/components/assessments/assessment-submission-form.tsx",
+  "src/components/reviews/review-queue.tsx",
+  "src/components/certificates/certificate-viewer.tsx",
+  "src/components/admin/admin-table.tsx",
+  "src/components/audit/audit-log-table.tsx"
 ];
 
 const actions = [
-  "server/actions/invitations/accept-invitation.ts",
-  "server/actions/payments/create-checkout-session.ts",
+  "src/server/actions/invitations/accept-invitation.ts",
+  "src/server/actions/payments/create-checkout-session.ts",
   "app/api/webhooks/stripe/route.ts",
-  "server/actions/enrolments/manual-enrolment.ts",
-  "server/actions/profiles/update-profile.ts",
-  "server/actions/progress/record-progress-event.ts",
-  "server/actions/assessments/submit-assessment.ts",
-  "server/actions/ai/evaluate-assessment-via-aimc.ts",
-  "server/actions/reviews/review-assessment.ts",
-  "server/actions/certificates/generate-certificate.ts",
-  "lib/services/audit/write-audit-log.ts"
+  "src/server/actions/enrolments/manual-enrolment.ts",
+  "src/server/actions/profiles/update-profile.ts",
+  "src/server/actions/progress/record-progress-event.ts",
+  "src/server/actions/assessments/submit-assessment.ts",
+  "src/server/actions/ai/evaluate-assessment-via-aimc.ts",
+  "src/server/actions/reviews/review-assessment.ts",
+  "src/server/actions/certificates/generate-certificate.ts",
+  "src/lib/services/audit/write-audit-log.ts"
 ];
 
 describe("ALP Stage 6 architecture inventory", () => {

--- a/tests/qa-to-red/alp/architecture-inventory.spec.ts
+++ b/tests/qa-to-red/alp/architecture-inventory.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "vitest";
+import { expectAnyPath, expectContains, expectPath } from "./helpers/project-root";
+
+const routes = [
+  ["QA-ALP-021", "app/(public)/login/page.tsx"],
+  ["QA-ALP-022", "app/(public)/invite/[token]/page.tsx"],
+  ["QA-ALP-023", "app/(public)/courses/[courseSlug]/buy/page.tsx"],
+  ["QA-ALP-024", "app/(public)/checkout/status/page.tsx"],
+  ["QA-ALP-025", "app/(learner)/dashboard/page.tsx"],
+  ["QA-ALP-026", "app/(learner)/profile/page.tsx"],
+  ["QA-ALP-027", "app/(learner)/learn/[courseSlug]/page.tsx"],
+  ["QA-ALP-028", "app/(learner)/learn/[courseSlug]/units/[unitSlug]/page.tsx"],
+  ["QA-ALP-029", "app/(learner)/learn/[courseSlug]/assessments/page.tsx"],
+  ["QA-ALP-030", "app/(learner)/learn/[courseSlug]/assessments/[assessmentId]/page.tsx"],
+  ["QA-ALP-031", "app/(learner)/certificates/page.tsx"],
+  ["QA-ALP-032", "app/(learner)/certificates/[certificateId]/page.tsx"],
+  ["QA-ALP-033", "app/(admin)/admin/page.tsx"],
+  ["QA-ALP-034", "app/(admin)/admin/learners/page.tsx"],
+  ["QA-ALP-035", "app/(admin)/admin/enrolments/page.tsx"],
+  ["QA-ALP-036", "app/(admin)/admin/courses/page.tsx"],
+  ["QA-ALP-037", "app/(admin)/admin/assessments/page.tsx"],
+  ["QA-ALP-038", "app/(admin)/admin/reviews/page.tsx"],
+  ["QA-ALP-039", "app/(admin)/admin/payments/page.tsx"],
+  ["QA-ALP-040", "app/(admin)/admin/certificates/page.tsx"],
+  ["QA-ALP-041", "app/(admin)/admin/reports/page.tsx"],
+  ["QA-ALP-042", "app/(admin)/admin/audit/page.tsx"],
+  ["QA-ALP-044", "app/not-found.tsx"],
+  ["QA-ALP-045", "app/error.tsx"]
+];
+
+const components = [
+  "components/layout/app-shell.tsx",
+  "components/auth/protected-layout.tsx",
+  "components/auth/login-form.tsx",
+  "components/dashboard/learner-dashboard.tsx",
+  "components/course/course-shell.tsx",
+  "components/course/course-sidebar.tsx",
+  "components/course/unit-viewer.tsx",
+  "components/progress/progress-indicator.tsx",
+  "components/assessments/assessment-submission-form.tsx",
+  "components/reviews/review-queue.tsx",
+  "components/certificates/certificate-viewer.tsx",
+  "components/admin/admin-table.tsx",
+  "components/audit/audit-log-table.tsx"
+];
+
+const actions = [
+  "server/actions/invitations/accept-invitation.ts",
+  "server/actions/payments/create-checkout-session.ts",
+  "app/api/webhooks/stripe/route.ts",
+  "server/actions/enrolments/manual-enrolment.ts",
+  "server/actions/profiles/update-profile.ts",
+  "server/actions/progress/record-progress-event.ts",
+  "server/actions/assessments/submit-assessment.ts",
+  "server/actions/ai/evaluate-assessment-via-aimc.ts",
+  "server/actions/reviews/review-assessment.ts",
+  "server/actions/certificates/generate-certificate.ts",
+  "lib/services/audit/write-audit-log.ts"
+];
+
+describe("ALP Stage 6 architecture inventory", () => {
+  for (const [qaId, path] of routes) {
+    it(`${qaId} route exists: ${path}`, () => expectPath(path, qaId));
+  }
+
+  it("QA-ALP-043 unauthorized route exists", () => {
+    expectAnyPath(["app/unauthorized.tsx", "app/(public)/unauthorized/page.tsx"], "QA-ALP-043");
+  });
+
+  for (const path of components) {
+    it(`component exists: ${path}`, () => expectPath(path, `COMP-${path}`));
+  }
+
+  for (const path of actions) {
+    it(`server action or API exists: ${path}`, () => expectPath(path, `ACTION-${path}`));
+  }
+
+  it("QA-ALP-057 migration set exists", () => {
+    expectPath("supabase/migrations/001_alp_auth_profile.sql", "QA-ALP-057");
+    expectPath("supabase/migrations/007_alp_rls_policies.sql", "QA-ALP-057");
+  });
+
+  it("QA-ALP-058 .env.example exists and contains core variables", () => {
+    expectPath(".env.example", "QA-ALP-058");
+    expectContains(".env.example", "NEXT_PUBLIC_SUPABASE_URL", "QA-ALP-059");
+    expectContains(".env.example", "STRIPE_SECRET_KEY", "QA-ALP-060");
+    expectContains(".env.example", "AIMC_GATEWAY_URL", "QA-ALP-061");
+  });
+});

--- a/tests/qa-to-red/alp/assessment-submission.spec.ts
+++ b/tests/qa-to-red/alp/assessment-submission.spec.ts
@@ -8,22 +8,22 @@ describe("ALP Stage 6 assessment submission", () => {
   });
 
   it("QA-ALP-296 assessment submission action exists", () => {
-    expectPath("server/actions/assessments/submit-assessment.ts", "QA-ALP-296");
+    expectPath("src/server/actions/assessments/submit-assessment.ts", "QA-ALP-296");
     expectContains("supabase/migrations/005_alp_assessment_ai_review.sql", "assessment_submissions", "QA-ALP-296");
   });
 
   it("QA-ALP-297 evidence upload action exists", () => {
-    expectPath("server/actions/files/upload-assessment-file.ts", "QA-ALP-297");
+    expectPath("src/server/actions/files/upload-assessment-file.ts", "QA-ALP-297");
     expectContains("supabase/migrations/005_alp_assessment_ai_review.sql", "assessment_files", "QA-ALP-297");
   });
 
   it("QA-ALP-341 AI evaluation action uses AIMC", () => {
-    expectPath("server/actions/ai/evaluate-assessment-via-aimc.ts", "QA-ALP-341");
-    expectContains("server/actions/ai/evaluate-assessment-via-aimc.ts", "AIMC_GATEWAY", "QA-ALP-341");
+    expectPath("src/server/actions/ai/evaluate-assessment-via-aimc.ts", "QA-ALP-341");
+    expectContains("src/server/actions/ai/evaluate-assessment-via-aimc.ts", "AIMC_GATEWAY", "QA-ALP-341");
   });
 
   it("QA-ALP-381 review queue exists", () => {
     expectPath("app/(admin)/admin/reviews/page.tsx", "QA-ALP-381");
-    expectPath("server/actions/reviews/review-assessment.ts", "QA-ALP-381");
+    expectPath("src/server/actions/reviews/review-assessment.ts", "QA-ALP-381");
   });
 });

--- a/tests/qa-to-red/alp/assessment-submission.spec.ts
+++ b/tests/qa-to-red/alp/assessment-submission.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "vitest";
+import { expectContains, expectPath } from "./helpers/project-root";
+
+describe("ALP Stage 6 assessment submission", () => {
+  it("QA-ALP-291 assessment admin route and schema exist", () => {
+    expectPath("app/(admin)/admin/assessments/page.tsx", "QA-ALP-291");
+    expectContains("supabase/migrations/005_alp_assessment_ai_review.sql", "assessments", "QA-ALP-291");
+  });
+
+  it("QA-ALP-296 assessment submission action exists", () => {
+    expectPath("server/actions/assessments/submit-assessment.ts", "QA-ALP-296");
+    expectContains("supabase/migrations/005_alp_assessment_ai_review.sql", "assessment_submissions", "QA-ALP-296");
+  });
+
+  it("QA-ALP-297 evidence upload action exists", () => {
+    expectPath("server/actions/files/upload-assessment-file.ts", "QA-ALP-297");
+    expectContains("supabase/migrations/005_alp_assessment_ai_review.sql", "assessment_files", "QA-ALP-297");
+  });
+
+  it("QA-ALP-341 AI evaluation action uses AIMC", () => {
+    expectPath("server/actions/ai/evaluate-assessment-via-aimc.ts", "QA-ALP-341");
+    expectContains("server/actions/ai/evaluate-assessment-via-aimc.ts", "AIMC_GATEWAY", "QA-ALP-341");
+  });
+
+  it("QA-ALP-381 review queue exists", () => {
+    expectPath("app/(admin)/admin/reviews/page.tsx", "QA-ALP-381");
+    expectPath("server/actions/reviews/review-assessment.ts", "QA-ALP-381");
+  });
+});

--- a/tests/qa-to-red/alp/auth.spec.ts
+++ b/tests/qa-to-red/alp/auth.spec.ts
@@ -4,12 +4,12 @@ import { expectContains, expectPath } from "./helpers/project-root";
 describe("ALP Stage 6 auth and route protection", () => {
   it("QA-ALP-066 login form exists", () => {
     expectPath("app/(public)/login/page.tsx", "QA-ALP-066");
-    expectPath("components/auth/login-form.tsx", "QA-ALP-066");
+    expectPath("src/components/auth/login-form.tsx", "QA-ALP-066");
   });
 
   it("QA-ALP-071 admin route is protected", () => {
-    expectPath("components/auth/protected-layout.tsx", "QA-ALP-071");
-    expectContains("components/auth/protected-layout.tsx", "admin", "QA-ALP-071");
+    expectPath("src/components/auth/protected-layout.tsx", "QA-ALP-071");
+    expectContains("src/components/auth/protected-layout.tsx", "admin", "QA-ALP-071");
   });
 
   it("QA-ALP-077 user roles are schema-backed", () => {

--- a/tests/qa-to-red/alp/auth.spec.ts
+++ b/tests/qa-to-red/alp/auth.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "vitest";
+import { expectContains, expectPath } from "./helpers/project-root";
+
+describe("ALP Stage 6 auth and route protection", () => {
+  it("QA-ALP-066 login form exists", () => {
+    expectPath("app/(public)/login/page.tsx", "QA-ALP-066");
+    expectPath("components/auth/login-form.tsx", "QA-ALP-066");
+  });
+
+  it("QA-ALP-071 admin route is protected", () => {
+    expectPath("components/auth/protected-layout.tsx", "QA-ALP-071");
+    expectContains("components/auth/protected-layout.tsx", "admin", "QA-ALP-071");
+  });
+
+  it("QA-ALP-077 user roles are schema-backed", () => {
+    expectContains("supabase/migrations/001_alp_auth_profile.sql", "user_roles", "QA-ALP-077");
+  });
+
+  it("QA-ALP-080 server-only secrets are not client-facing", () => {
+    expectContains(".env.example", "SUPABASE_SERVICE_ROLE_KEY", "QA-ALP-080");
+  });
+});

--- a/tests/qa-to-red/alp/certificate.spec.ts
+++ b/tests/qa-to-red/alp/certificate.spec.ts
@@ -8,12 +8,12 @@ describe("ALP Stage 6 certificates", () => {
   });
 
   it("QA-ALP-421 certificate generation action and schema exist", () => {
-    expectPath("server/actions/certificates/generate-certificate.ts", "QA-ALP-421");
+    expectPath("src/server/actions/certificates/generate-certificate.ts", "QA-ALP-421");
     expectContains("supabase/migrations/006_alp_files_certificates_notifications_audit.sql", "certificates", "QA-ALP-421");
   });
 
   it("QA-ALP-424 certificate download action exists", () => {
-    expectPath("server/actions/certificates/get-certificate-file.ts", "QA-ALP-424");
+    expectPath("src/server/actions/certificates/get-certificate-file.ts", "QA-ALP-424");
   });
 
   it("QA-ALP-429 certificate events are auditable", () => {

--- a/tests/qa-to-red/alp/certificate.spec.ts
+++ b/tests/qa-to-red/alp/certificate.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "vitest";
+import { expectContains, expectPath } from "./helpers/project-root";
+
+describe("ALP Stage 6 certificates", () => {
+  it("QA-ALP-416 certificate routes exist", () => {
+    expectPath("app/(learner)/certificates/page.tsx", "QA-ALP-416");
+    expectPath("app/(learner)/certificates/[certificateId]/page.tsx", "QA-ALP-416");
+  });
+
+  it("QA-ALP-421 certificate generation action and schema exist", () => {
+    expectPath("server/actions/certificates/generate-certificate.ts", "QA-ALP-421");
+    expectContains("supabase/migrations/006_alp_files_certificates_notifications_audit.sql", "certificates", "QA-ALP-421");
+  });
+
+  it("QA-ALP-424 certificate download action exists", () => {
+    expectPath("server/actions/certificates/get-certificate-file.ts", "QA-ALP-424");
+  });
+
+  it("QA-ALP-429 certificate events are auditable", () => {
+    expectContains("supabase/migrations/006_alp_files_certificates_notifications_audit.sql", "certificate_events", "QA-ALP-429");
+  });
+});

--- a/tests/qa-to-red/alp/course-shell.spec.ts
+++ b/tests/qa-to-red/alp/course-shell.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it } from "vitest";
+import { expectContains, expectPath } from "./helpers/project-root";
+
+describe("ALP Stage 6 course shell and unit viewer", () => {
+  it("QA-ALP-211 course shell route and service exist", () => {
+    expectPath("app/(learner)/learn/[courseSlug]/page.tsx", "QA-ALP-211");
+    expectPath("lib/services/courses/get-course-shell.ts", "QA-ALP-211");
+  });
+
+  it("QA-ALP-213 sidebar and course hierarchy schema exist", () => {
+    expectPath("components/course/course-sidebar.tsx", "QA-ALP-213");
+    expectContains("supabase/migrations/002_alp_courses_content.sql", "course_modules", "QA-ALP-213");
+    expectContains("supabase/migrations/002_alp_courses_content.sql", "learning_units", "QA-ALP-213");
+  });
+
+  it("QA-ALP-217 unit viewer and content links exist", () => {
+    expectPath("components/course/unit-viewer.tsx", "QA-ALP-217");
+    expectContains("supabase/migrations/002_alp_courses_content.sql", "content_links", "QA-ALP-217");
+  });
+
+  it("QA-ALP-222 unit launch can record progress", () => {
+    expectPath("server/actions/progress/record-progress-event.ts", "QA-ALP-222");
+  });
+});

--- a/tests/qa-to-red/alp/course-shell.spec.ts
+++ b/tests/qa-to-red/alp/course-shell.spec.ts
@@ -4,21 +4,21 @@ import { expectContains, expectPath } from "./helpers/project-root";
 describe("ALP Stage 6 course shell and unit viewer", () => {
   it("QA-ALP-211 course shell route and service exist", () => {
     expectPath("app/(learner)/learn/[courseSlug]/page.tsx", "QA-ALP-211");
-    expectPath("lib/services/courses/get-course-shell.ts", "QA-ALP-211");
+    expectPath("src/lib/services/courses/get-course-shell.ts", "QA-ALP-211");
   });
 
   it("QA-ALP-213 sidebar and course hierarchy schema exist", () => {
-    expectPath("components/course/course-sidebar.tsx", "QA-ALP-213");
+    expectPath("src/components/course/course-sidebar.tsx", "QA-ALP-213");
     expectContains("supabase/migrations/002_alp_courses_content.sql", "course_modules", "QA-ALP-213");
     expectContains("supabase/migrations/002_alp_courses_content.sql", "learning_units", "QA-ALP-213");
   });
 
   it("QA-ALP-217 unit viewer and content links exist", () => {
-    expectPath("components/course/unit-viewer.tsx", "QA-ALP-217");
+    expectPath("src/components/course/unit-viewer.tsx", "QA-ALP-217");
     expectContains("supabase/migrations/002_alp_courses_content.sql", "content_links", "QA-ALP-217");
   });
 
   it("QA-ALP-222 unit launch can record progress", () => {
-    expectPath("server/actions/progress/record-progress-event.ts", "QA-ALP-222");
+    expectPath("src/server/actions/progress/record-progress-event.ts", "QA-ALP-222");
   });
 });

--- a/tests/qa-to-red/alp/deployment-cwt.spec.ts
+++ b/tests/qa-to-red/alp/deployment-cwt.spec.ts
@@ -3,15 +3,15 @@ import { expectContains, expectPath } from "./helpers/project-root";
 
 describe("ALP Stage 6 deployment and CWT evidence", () => {
   it("QA-ALP-636 package build script exists", () => {
-    expectContains("package.json", "\"build\"", "QA-ALP-636");
+    expectContains("package.json", "\"build\": \"next build\"", "QA-ALP-636");
   });
 
   it("QA-ALP-637 package typecheck script exists", () => {
-    expectContains("package.json", "\"typecheck\"", "QA-ALP-637");
+    expectContains("package.json", "\"typecheck\": \"tsc --noEmit\"", "QA-ALP-637");
   });
 
   it("QA-ALP-642 environment validation module exists", () => {
-    expectPath("lib/config/env.ts", "QA-ALP-642");
+    expectPath("src/lib/config/env.ts", "QA-ALP-642");
   });
 
   it("QA-ALP-643 Stripe webhook route exists", () => {

--- a/tests/qa-to-red/alp/deployment-cwt.spec.ts
+++ b/tests/qa-to-red/alp/deployment-cwt.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it } from "vitest";
+import { expectContains, expectPath } from "./helpers/project-root";
+
+describe("ALP Stage 6 deployment and CWT evidence", () => {
+  it("QA-ALP-636 package build script exists", () => {
+    expectContains("package.json", "\"build\"", "QA-ALP-636");
+  });
+
+  it("QA-ALP-637 package typecheck script exists", () => {
+    expectContains("package.json", "\"typecheck\"", "QA-ALP-637");
+  });
+
+  it("QA-ALP-642 environment validation module exists", () => {
+    expectPath("lib/config/env.ts", "QA-ALP-642");
+  });
+
+  it("QA-ALP-643 Stripe webhook route exists", () => {
+    expectPath("app/api/webhooks/stripe/route.ts", "QA-ALP-643");
+  });
+
+  it("QA-ALP-657 CWT closure report exists", () => {
+    expectPath("architecture/builds/ALP_BUILD_001_DRAFT/CWT_CLOSURE_REPORT.md", "QA-ALP-657");
+  });
+
+  it("QA-ALP-660 fully functional proof exists before handover", () => {
+    expectContains("architecture/builds/ALP_BUILD_001_DRAFT/CWT_CLOSURE_REPORT.md", "Fully Functional", "QA-ALP-660");
+  });
+});

--- a/tests/qa-to-red/alp/governance-artifacts.spec.ts
+++ b/tests/qa-to-red/alp/governance-artifacts.spec.ts
@@ -1,9 +1,12 @@
 import { describe, it } from "vitest";
-import { expectContains, expectPath } from "./helpers/project-root";
+import { expectAnyPath, expectContains, expectPath } from "./helpers/project-root";
 
 describe("ALP Stage 6 governance artifacts", () => {
   it("QA-ALP-001 app description exists", () => {
-    expectPath("modules/ALP/00-app-description/app-description.md", "QA-ALP-001");
+    expectAnyPath([
+      "modules/ALP/00-app-description/app-description.md",
+      "modules/ALP/00-app-description/APGI_LEARNING_PORTAL_APP_DESCRIPTION.md"
+    ], "QA-ALP-001");
   });
 
   it("QA-ALP-002 UX workflow and wiring spec exists", () => {

--- a/tests/qa-to-red/alp/governance-artifacts.spec.ts
+++ b/tests/qa-to-red/alp/governance-artifacts.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it } from "vitest";
+import { expectContains, expectPath } from "./helpers/project-root";
+
+describe("ALP Stage 6 governance artifacts", () => {
+  it("QA-ALP-001 app description exists", () => {
+    expectPath("modules/ALP/00-app-description/app-description.md", "QA-ALP-001");
+  });
+
+  it("QA-ALP-002 UX workflow and wiring spec exists", () => {
+    expectPath("modules/ALP/01-ux-workflow-wiring/ux-workflow-wiring-spec.md", "QA-ALP-002");
+  });
+
+  it("QA-ALP-003 FRS exists", () => {
+    expectPath("modules/ALP/02-frs/functional-requirements.md", "QA-ALP-003");
+  });
+
+  it("QA-ALP-005 TRS exists", () => {
+    expectPath("modules/ALP/03-trs/technical-requirements-specification.md", "QA-ALP-005");
+  });
+
+  it("QA-ALP-006 hardened architecture exists", () => {
+    expectPath("modules/ALP/04-architecture/architecture.md", "QA-ALP-006");
+    expectContains("modules/ALP/04-architecture/architecture.md", "Architecture v0.2", "QA-ALP-006");
+  });
+
+  it("QA-ALP-008 requirement registry exists", () => {
+    expectPath("modules/ALP/REQUIREMENT_REGISTRY.md", "QA-ALP-008");
+  });
+
+  it("QA-ALP-009 QA-to-Red specification exists", () => {
+    expectPath("modules/ALP/05-qa-to-red/qa-to-red.md", "QA-ALP-009");
+  });
+
+  it("QA-ALP-010 build remains blocked", () => {
+    expectContains("modules/ALP/05-qa-to-red/qa-to-red.md", "Build Authorized? | No", "QA-ALP-010");
+  });
+
+  it("QA-ALP-015 QA catalog alignment exists", () => {
+    expectPath("modules/ALP/05-qa-to-red/qa-catalog-alignment.md", "QA-ALP-015");
+  });
+});

--- a/tests/qa-to-red/alp/helpers/project-root.ts
+++ b/tests/qa-to-red/alp/helpers/project-root.ts
@@ -1,0 +1,28 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect } from "vitest";
+
+export function root(): string {
+  return process.env.ALP_REPO_ROOT ?? process.cwd();
+}
+
+export function exists(path: string): boolean {
+  return existsSync(join(root(), path));
+}
+
+export function read(path: string): string {
+  return readFileSync(join(root(), path), "utf8");
+}
+
+export function expectPath(path: string, qaId: string): void {
+  expect(exists(path), `${qaId}: expected repository path ${path}`).toBe(true);
+}
+
+export function expectContains(path: string, text: string, qaId: string): void {
+  expectPath(path, qaId);
+  expect(read(path).includes(text), `${qaId}: expected ${path} to contain ${text}`).toBe(true);
+}
+
+export function expectAnyPath(paths: string[], qaId: string): void {
+  expect(paths.some(exists), `${qaId}: expected one of ${paths.join(", ")}`).toBe(true);
+}

--- a/tests/qa-to-red/alp/security-privacy.spec.ts
+++ b/tests/qa-to-red/alp/security-privacy.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it } from "vitest";
+import { expectContains, expectPath } from "./helpers/project-root";
+
+describe("ALP Stage 6 security privacy and RLS", () => {
+  it("QA-ALP-526 RLS migration exists", () => {
+    expectPath("supabase/migrations/007_alp_rls_policies.sql", "QA-ALP-526");
+  });
+
+  it("QA-ALP-527 profile RLS uses auth.uid", () => {
+    expectContains("supabase/migrations/007_alp_rls_policies.sql", "profiles", "QA-ALP-527");
+    expectContains("supabase/migrations/007_alp_rls_policies.sql", "auth.uid()", "QA-ALP-527");
+  });
+
+  it("QA-ALP-535 Stripe webhook uses signing secret", () => {
+    expectContains("app/api/webhooks/stripe/route.ts", "STRIPE_WEBHOOK_SECRET", "QA-ALP-535");
+  });
+
+  it("QA-ALP-538 private storage is configured", () => {
+    expectContains(".env.example", "PRIVATE_FILE_BUCKET", "QA-ALP-538");
+  });
+});


### PR DESCRIPTION
## Summary

Adds the APGI Learning Portal Stage 6 QA-to-Red baseline to `APGI-cmy/Training`.

This PR adds:

- `modules/ALP/05-qa-to-red/qa-to-red.md`
- `modules/ALP/05-qa-to-red/qa-catalog-alignment.md`
- executable Vitest RED tests under `tests/qa-to-red/alp/`
- `test:alp:red*` scripts and `vitest` dev dependency in `package.json`

## Governance status

This PR is **Stage 6 QA-to-Red only**.

It does **not** authorize:

- PBFAG
- implementation/build
- production deployment

## Important note

The RED proof report file could not be created through the connector because that file payload was blocked by a tool-side safety filter. The PR still includes the executable RED test baseline and QA Catalog alignment artifact. The next step after merge or update is to run:

```bash
npm run test:alp:red
```

and file:

```text
modules/ALP/05-qa-to-red/red-proof-report.md
```

with real command output.

## Expected RED behavior

The suite should fail before implementation because the ALP LMS routes, components, server actions, migrations, RLS policies, env example, deployment evidence, and CWT proof are not yet implemented/filed.

Correct RED means the tests execute and fail for missing required implementation, not test-runner failure.

## Next governed stage

Stage 7 PBFAG remains blocked until executable RED proof and final QA Catalog alignment are filed.