### PR TITLE
Add ALP Stage 7 PBFAG checklist

### DIFF
--- a/modules/ALP/06-pbfag/pbfag.md
+++ b/modules/ALP/06-pbfag/pbfag.md
@@ -1,0 +1,241 @@
+# APGI Learning Portal - Stage 7 PBFAG
+
+## Status Header
+
+| Field | Value |
+|---|---|
+| Artifact | Pre-Build Foreman Authorization Gate |
+| Module | ALP - APGI Learning Portal |
+| Stage | 7 - PBFAG |
+| Version | 0.1 |
+| Status | Draft - Foundation PASS; Build Authorization remains BLOCKED |
+| Repository | APGI-cmy/Training |
+| Canonical Path | modules/ALP/06-pbfag/pbfag.md |
+| Prepared Date | 2026-06-10 |
+| Prepared By | ChatGPT acting as Product Owner / Foreman / Governance proxy at user request |
+| Upstream Stage 6 PR | #46 - Add ALP Stage 6 QA-to-Red executable tests |
+| Build Authorized? | No |
+| Builder Appointment Authorized? | No |
+| Implementation Authorized? | No |
+
+---
+
+## 1. Purpose
+
+This artifact records the Stage 7 Pre-Build Foreman Authorization Gate for the APGI Learning Portal.
+
+The purpose of this gate is to verify whether the Stage 1-6 foundation is sufficiently complete to proceed toward downstream pre-build planning, while preserving the build block until all remaining pre-build stages are complete.
+
+Stage 7 is not implementation authorization. Stage 7 is the formal pre-authorization checkpoint that validates QA Catalog alignment, QA-to-Red foundation, architecture alignment, BL/FL-CI ratchet status, dependency gates, and warning status before any builder appointment or build authorization is considered.
+
+---
+
+## 2. Canonical Authority
+
+This PBFAG is governed by:
+
+```text
+governance/canon/FM_PREAUTH_CHECKLIST_CANON.md
+```
+
+The canon requires an explicit pre-authorization checklist before declaring work ready for authorization or issuing builder appointments. It requires validation of QA Catalog alignment, QA-to-Red foundation completeness, Architecture alignment, BL/FL-CI ratchet compliance, dependency gate satisfaction, and warning status.
+
+---
+
+## 3. Upstream Artifact Chain
+
+| Stage | Artifact | Status |
+|---|---|---|
+| Stage 1 | `modules/ALP/00-app-description/APGI_LEARNING_PORTAL_APP_DESCRIPTION.md` | Filed on main |
+| Stage 2 | `modules/ALP/01-ux-workflow-wiring/ux-workflow-wiring-spec.md` | Required / must be filed if not present |
+| Stage 3 | `modules/ALP/02-frs/functional-requirements.md` | Required / must be filed if not present |
+| Stage 4 | `modules/ALP/03-trs/technical-requirements-specification.md` | Required / must be filed if not present |
+| Stage 5 | `modules/ALP/04-architecture/architecture.md` | Required / must be filed if not present |
+| Stage 6 | `modules/ALP/05-qa-to-red/qa-to-red.md` | Filed by PR #46 |
+| Stage 6 | `modules/ALP/05-qa-to-red/qa-catalog-alignment.md` | Filed by PR #46 |
+| Stage 6 | `modules/ALP/05-qa-to-red/red-proof-report.md` | Filed by PR #46 |
+
+### Stage Chain Finding
+
+Stage 6 has been merged and RED proof is filed. Several upstream artifacts are referenced by the Stage 6 RED suite as required files and may intentionally still be RED/missing in `main`. This gate therefore passes the Stage 6 filing requirement but preserves downstream build block until all required upstream artifacts are canonically filed.
+
+---
+
+## 4. PBFAG Checklist
+
+### 4.1 QA Catalog Alignment
+
+| Check | Result | Evidence |
+|---|---|---|
+| QA range exists | PASS | `QA-ALP-001` through `QA-ALP-700` reserved in `qa-catalog-alignment.md` |
+| Semantic alignment | PASS | QA domains map to ALP governance, architecture, auth, course, assessment, certificate, RLS, deployment, and CWT |
+| Collision prevention | CONDITIONAL PASS | Module-local range reserved; canonical catalog registration/acceptance remains required before builder appointment |
+| QA Catalog artifact filed | PASS | `modules/ALP/05-qa-to-red/qa-catalog-alignment.md` |
+
+**Finding**: QA Catalog alignment is acceptable for Stage 7 pre-build planning, but not sufficient for builder appointment until the module-local range is formally accepted or registered.
+
+---
+
+### 4.2 QA-to-Red Foundation
+
+| Check | Result | Evidence |
+|---|---|---|
+| RED test files exist | PASS | `tests/qa-to-red/alp/*.spec.ts` merged in PR #46 |
+| Test file paths documented | PASS | `qa-to-red.md` and test files |
+| QA coverage exists | PASS | Governance, architecture inventory, auth, course shell, assessment, certificate, RLS/security, deployment/CWT |
+| RED status proven | PASS | `red-proof-report.md` records Vitest execution |
+| Test infrastructure works | PASS | RED proof records Vitest started, tests compiled, and failures were assertion failures |
+| Failures are correct RED | PASS | RED proof records missing ALP files/artifacts as expected failures |
+
+**RED Proof Summary**:
+
+```text
+Test files executed: 8
+Test files failed: 8
+Total tests: 87
+Failed tests: 81
+Passed tests: 6
+```
+
+**Finding**: QA-to-Red foundation passes Stage 7 PBFAG for pre-build planning. Build remains blocked because RED tests are expected to fail until implementation.
+
+---
+
+### 4.3 Architecture Alignment
+
+| Check | Result | Evidence |
+|---|---|---|
+| Architecture-derived QA exists | PASS | Stage 6 tests cover architecture inventory, route files, component files, server actions, migrations, env, RLS, deployment, CWT |
+| Architecture completeness addressed | CONDITIONAL PASS | Hardened Architecture v0.2 was used as source in Stage 6 specification |
+| Architecture file present on main | TO VERIFY / BLOCKER IF MISSING | `modules/ALP/04-architecture/architecture.md` must be filed before builder appointment |
+| No QA scope outside Architecture | PASS | QA tests assert architecture-mandated ALP LMS boundaries |
+
+**Finding**: Architecture-to-QA alignment is acceptable as a Stage 7 planning basis. If the Architecture artifact is not yet filed on `main`, it remains a blocking prerequisite before builder appointment or build authorization.
+
+---
+
+### 4.4 BL/FL-CI Ratchet Status
+
+| Check | Result | Evidence |
+|---|---|---|
+| Known Stage 6 failure pattern reviewed | PASS | Tooling/connector limitations were addressed by filing PR #46 and RED proof |
+| Copilot review feedback addressed | PASS | PR #46 patched path alignment, App Description path, script assertions, env path |
+| Vercel LFS failure addressed | PASS | Unused `.gitattributes` LFS tracking rule removed before merge |
+| New BL/FL-CI entry required? | WATCH | A follow-up learning may be warranted for GitHub/Vercel LFS budget blocking required checks |
+| Second-time failure prevention | CONDITIONAL PASS | Future PRs should avoid LFS tracking unless actual LFS assets are required and budget is confirmed |
+
+**Finding**: No active BL/FL-CI blocker prevents Stage 7 filing. A governance learning may be opened later for the LFS merge-gate issue if repeated.
+
+---
+
+### 4.5 Dependency Gates
+
+| Dependency | Result | Evidence / Note |
+|---|---|---|
+| Stage 6 merged | PASS | PR #46 merged into `main` |
+| RED proof filed | PASS | `red-proof-report.md` present on `main` |
+| Vercel gate passed for PR #46 | PASS BY MERGE FACT | PR was merged after required gate satisfaction or admin-approved merge |
+| Upstream Stage 1-5 artifacts physically filed | CONDITIONAL / VERIFY | Stage 7 preserves blocker if missing |
+| Requirement Registry filed | CONDITIONAL / VERIFY | Required before builder appointment |
+| Implementation Plan exists | NOT YET | Stage 8 pending |
+| Builder Checklist exists | NOT YET | Stage 9 pending |
+| IAA Pre-Brief exists | NOT YET | Stage 10 pending |
+| Builder Appointment exists | NOT YET | Stage 11 pending |
+
+**Finding**: Dependencies are sufficient to file Stage 7, not sufficient to authorize build.
+
+---
+
+### 4.6 Warning Status Validation
+
+| Check | Result | Evidence / Note |
+|---|---|---|
+| Prior PR warnings reviewed | PASS | PR #46 Copilot findings were reviewed and patched before merge |
+| CI/Vercel warnings clear | PASS BY MERGE FACT / VERIFY | PR was merged after required gate satisfaction; any remaining warnings must be reviewed before builder appointment |
+| Warning whitelist needed | NOT IDENTIFIED | No warning whitelist was introduced |
+| Warning discovery obligation carried forward | PASS | Build remains blocked; later stages must include warning discovery obligations |
+
+**Finding**: No known unresolved warning blocks Stage 7 filing. Warning-free status must be rechecked before builder appointment.
+
+---
+
+## 5. PBFAG Decision
+
+### Stage 7 Filing Decision
+
+```text
+PASS - Stage 7 PBFAG may be filed.
+```
+
+### Builder Appointment Decision
+
+```text
+BLOCKED - Builder appointment is not authorized.
+```
+
+### Build Authorization Decision
+
+```text
+BLOCKED - Implementation/build is not authorized.
+```
+
+### Reason for Build Block
+
+Build remains blocked because downstream pre-build stages are still required:
+
+```text
+Stage 8 - Implementation Plan
+Stage 9 - Builder Checklist
+Stage 10 - IAA Pre-Brief
+Stage 11 - Builder Appointment
+Stage 12 - Build Authorization / Build Execution
+```
+
+Additionally, any missing Stage 1-5 canonical artifacts must be filed before builder appointment.
+
+---
+
+## 6. Required Carry-Forward Items
+
+| Carry-Forward ID | Item | Required Before |
+|---|---|---|
+| PBFAG-CF-001 | Verify/file Stage 2 UX Workflow & Wiring Spec on `main` | Builder Appointment |
+| PBFAG-CF-002 | Verify/file Stage 3 FRS on `main` | Builder Appointment |
+| PBFAG-CF-003 | Verify/file Stage 4 TRS on `main` | Builder Appointment |
+| PBFAG-CF-004 | Verify/file Stage 5 Architecture v0.2 on `main` | Builder Appointment |
+| PBFAG-CF-005 | Verify/file Requirement Registry on `main` | Builder Appointment |
+| PBFAG-CF-006 | Confirm QA-ALP range accepted as module-local or canonical catalog registered | Builder Appointment |
+| PBFAG-CF-007 | Produce Stage 8 Implementation Plan | Stage 8 |
+| PBFAG-CF-008 | Produce Stage 9 Builder Checklist | Stage 9 |
+| PBFAG-CF-009 | Produce Stage 10 IAA Pre-Brief | Stage 10 |
+| PBFAG-CF-010 | Confirm all required checks and warnings before Stage 11 | Builder Appointment |
+
+---
+
+## 7. Proxy Sign-Off
+
+I, ChatGPT acting as Product Owner / Foreman / Governance proxy at the user request, record that the Stage 7 PBFAG checklist has been executed against the available Stage 1-6 chain.
+
+I find that Stage 6 QA-to-Red and RED proof have been filed and are sufficient to proceed to Stage 8 Implementation Plan drafting.
+
+I do not authorize implementation, builder appointment, or build execution.
+
+---
+
+## 8. Next Stage
+
+Proceed to:
+
+```text
+modules/ALP/07-implementation-plan/implementation-plan.md
+```
+
+Build remains blocked.
+
+---
+
+## 9. Change History
+
+| Version | Date | Change Description | Changed By | Approval |
+|---|---|---|---|---|
+| 0.1 | 2026-06-10 | Initial Stage 7 PBFAG created after PR #46 merge and RED proof filing. | ChatGPT acting as Product Owner / Foreman / Governance proxy | Draft PASS for Stage 8 planning; build blocked |


### PR DESCRIPTION
## Summary

Adds Stage 7 PBFAG for the APGI Learning Portal after PR #46 merged Stage 6 QA-to-Red and RED proof.

## Adds

- `modules/ALP/06-pbfag/pbfag.md`

## Governance status

This PR records the Pre-Build Foreman Authorization Gate as a **Stage 7 filing**.

Decision inside the artifact:

- Stage 7 filing: PASS
- Stage 8 Implementation Plan drafting: allowed next
- Builder appointment: blocked
- Build / implementation: blocked

## Important carry-forward blockers

Before builder appointment/build authorization, the following must still be verified/filed:

- Stage 2 UX Workflow & Wiring Spec on `main`
- Stage 3 FRS on `main`
- Stage 4 TRS on `main`
- Stage 5 Architecture v0.2 on `main`
- Requirement Registry on `main`
- QA-ALP range accepted as module-local or canonical catalog registered
- Stage 8 Implementation Plan
- Stage 9 Builder Checklist
- Stage 10 IAA Pre-Brief
- Stage 11 Builder Appointment

## Build status

This PR does **not** authorize build.

## Upstream reference

- PR #46 merged Stage 6 QA-to-Red executable tests and RED proof.