### PR TITLE
Add blocked ALP Stage 12 build authorization scaffold

### DIFF
--- a/modules/ALP/11-build/build-authorization.md
+++ b/modules/ALP/11-build/build-authorization.md
@@ -4,11 +4,11 @@
 
 | Field | Value |
 |---|---|
-| Artifact | Build Authorization Scaffold |
+| Artifact | Blocked Build Authorization Readiness Record |
 | Module | ALP - APGI Learning Portal |
 | Stage | 12 - Build / Build Authorization |
-| Version | 0.1 |
-| Status | BLOCKED - build authorization scaffold filed; no build authorized |
+| Version | 0.2 |
+| Status | BLOCKED - readiness record only; Stage 12 entry conditions not met; no build authorized |
 | Repository | APGI-cmy/Training |
 | Canonical Path | modules/ALP/11-build/build-authorization.md |
 | Prepared Date | 2026-06-11 |
@@ -17,16 +17,17 @@
 | Build Authorized? | No |
 | Builder Appointment Authorized? | No |
 | Implementation Authorized? | No |
+| Stage 12 Gate Passed? | No |
 
 ---
 
 ## 1. Purpose
 
-This Stage 12 artifact records the APGI Learning Portal build authorization gate.
+This artifact records the APGI Learning Portal build authorization readiness gate and the reasons build remains blocked.
 
-It is intentionally filed as a blocked build-authorization scaffold because Stage 11 currently contains an appointment-record scaffold only. No actual builders have been appointed, and build execution must remain blocked.
+It is intentionally filed as a blocked readiness record because Stage 11 currently contains an appointment-record scaffold only. No actual builders have been appointed, and build execution must remain blocked.
 
-This artifact does not authorize implementation.
+This artifact does not satisfy Stage 12 entry conditions, does not mark Stage 12 as passed, and does not authorize implementation.
 
 ---
 
@@ -37,14 +38,17 @@ The Pre-Build Stage Model defines Stage 12 as the point where Build-to-Green exe
 Stage 12 entry conditions require:
 
 - all Stages 1-11 complete and gate-passed;
-- builder formally appointed at Stage 11;
-- implementation waves executed according to the Stage 8 Implementation Plan;
+- builder formally appointed at Stage 11.
+
+After authorization is granted, execution must then follow these constraints:
+
+- implementation waves must execute according to the Stage 8 Implementation Plan;
 - build-to-green target: GREEN QA suite at the end of each wave;
 - no scope deviation without Foreman approval and change-propagation audit;
 - STOP-AND-FIX at the first failing gate;
-- merge gates passing before wave closure.
+- merge gates must pass before wave closure.
 
-Because Stage 11 did not appoint any builders, Stage 12 is blocked.
+Because Stage 11 did not appoint any builders, Stage 12 entry conditions are not met and build authorization is blocked.
 
 ---
 
@@ -57,7 +61,7 @@ Because Stage 11 did not appoint any builders, Stage 12 is blocked.
 | Stage 8 Implementation Plan | Filed and accepted | Filed | Satisfied for planning |
 | Stage 9 Builder Checklist | PASS for appointed builders | Checklist filed; candidate acknowledgements pending | Blocks build |
 | Stage 10 IAA Pre-Brief | Acknowledged by Foreman/builders; assurance/advisory recorded | Artifact filed; acknowledgements/advisory pending | Blocks build |
-| Stage 11 Builder Appointment | Formal appointed builders recorded | Scaffold filed; no builders appointed | Blocks build |
+| Stage 11 Builder Appointment | Formally appointed builders recorded | Scaffold filed; no builders appointed | Blocks build |
 
 ---
 
@@ -176,17 +180,18 @@ No local-only proof is sufficient for deployment or final CWT closure.
 
 | Gate Item | Result | Reason |
 |---|---|---|
-| Stage 12 artifact exists | PASS when merged | This file |
-| Build scope recorded | PASS | Section 5 |
-| Build-to-Green constraints recorded | PASS | Section 6 |
-| Wave authorization register exists | PASS | Section 7 |
-| Evidence requirements recorded | PASS | Section 8 |
+| Blocked readiness record exists | FILED | This file records why Stage 12 cannot pass yet |
+| Build scope recorded for future authorization | RECORDED | Section 5 |
+| Build-to-Green constraints recorded for future authorization | RECORDED | Section 6 |
+| Wave authorization register exists | RECORDED | Section 7 |
+| Evidence requirements recorded | RECORDED | Section 8 |
 | Stage 11 named builders appointed | FAIL | No builders appointed |
 | Stage 9 checklist PASS per appointed builder | FAIL | No appointed builders |
 | Stage 10 acknowledgements complete | FAIL | Pending |
 | ASSURANCE-TOKEN / PHASE_A_ADVISORY recorded | FAIL | Pending |
 | Runtime/Deployment Contract filed | FAIL | Pending |
 | Golden Path Verification Pack filed | FAIL | Pending |
+| Stage 12 gate passed | NO | Entry conditions are not met |
 | Build authorized | NO | Blocked by failed gate items |
 
 ---
@@ -195,25 +200,26 @@ No local-only proof is sufficient for deployment or final CWT closure.
 
 ```text
 Stage 12 Build Authorization: BLOCKED.
+Stage 12 Gate Passed: NO.
 Build / Implementation: BLOCKED.
 Reason: Stage 11 contains no actual appointed builders and required acknowledgement / assurance / readiness blockers remain open.
 ```
 
-This artifact is complete as a blocked build-authorization scaffold. It does not authorize any implementation work.
+This artifact is complete only as a blocked build-authorization readiness record. It does not satisfy Stage 12 entry conditions and does not authorize any implementation work.
 
 ---
 
 ## 11. Proxy Sign-Off
 
-I, ChatGPT acting as Product Owner / Foreman / Governance proxy at user request, record that this Stage 12 artifact defines the build-authorization gate, remaining blockers, authorized scope boundaries, execution constraints, wave authorization register, and evidence requirements.
+I, ChatGPT acting as Product Owner / Foreman / Governance proxy at user request, record that this artifact defines the build-authorization gate, remaining blockers, future authorized scope boundaries, execution constraints, wave authorization register, and evidence requirements.
 
-I do not authorize build or implementation.
+I do not mark Stage 12 passed and do not authorize build or implementation.
 
 ---
 
 ## 12. Required Follow-Up Before Build Can Start
 
-To move from blocked scaffold to actual build authorization, complete all of the following:
+To move from blocked readiness record to actual build authorization, complete all of the following:
 
 1. update Stage 11 with named builder appointments;
 2. complete Stage 9 checklist PASS evidence for appointed builders;
@@ -235,3 +241,4 @@ Until then, build remains blocked.
 | Version | Date | Change Description | Changed By | Approval |
 |---|---|---|---|---|
 | 0.1 | 2026-06-11 | Initial blocked Stage 12 Build Authorization scaffold created after Stage 11 appointment-record scaffold merge. | ChatGPT acting as Product Owner / Foreman / Governance proxy | BLOCKED - no build authorization |
+| 0.2 | 2026-06-11 | Clarified that this file is a blocked readiness record only and does not mark Stage 12 as passed. | ChatGPT acting as Product Owner / Foreman / Governance proxy | BLOCKED - Stage 12 entry conditions not met |

--- a/modules/ALP/11-build/build-authorization.md
+++ b/modules/ALP/11-build/build-authorization.md
@@ -1,0 +1,237 @@
+# APGI Learning Portal - Stage 12 Build Authorization
+
+## Status Header
+
+| Field | Value |
+|---|---|
+| Artifact | Build Authorization Scaffold |
+| Module | ALP - APGI Learning Portal |
+| Stage | 12 - Build / Build Authorization |
+| Version | 0.1 |
+| Status | BLOCKED - build authorization scaffold filed; no build authorized |
+| Repository | APGI-cmy/Training |
+| Canonical Path | modules/ALP/11-build/build-authorization.md |
+| Prepared Date | 2026-06-11 |
+| Prepared By | ChatGPT acting as Product Owner / Foreman / Governance proxy at user request |
+| Upstream Stage 11 | modules/ALP/10-builder-appointment/builder-appointment.md |
+| Build Authorized? | No |
+| Builder Appointment Authorized? | No |
+| Implementation Authorized? | No |
+
+---
+
+## 1. Purpose
+
+This Stage 12 artifact records the APGI Learning Portal build authorization gate.
+
+It is intentionally filed as a blocked build-authorization scaffold because Stage 11 currently contains an appointment-record scaffold only. No actual builders have been appointed, and build execution must remain blocked.
+
+This artifact does not authorize implementation.
+
+---
+
+## 2. Canonical Authority
+
+The Pre-Build Stage Model defines Stage 12 as the point where Build-to-Green execution may begin only after the full pre-build chain is complete and governance-valid.
+
+Stage 12 entry conditions require:
+
+- all Stages 1-11 complete and gate-passed;
+- builder formally appointed at Stage 11;
+- implementation waves executed according to the Stage 8 Implementation Plan;
+- build-to-green target: GREEN QA suite at the end of each wave;
+- no scope deviation without Foreman approval and change-propagation audit;
+- STOP-AND-FIX at the first failing gate;
+- merge gates passing before wave closure.
+
+Because Stage 11 did not appoint any builders, Stage 12 is blocked.
+
+---
+
+## 3. Upstream Gate Status
+
+| Stage | Required Before Build | Current Status | Build Impact |
+|---|---|---|---|
+| Stage 6 QA-to-Red | RED suites and proof filed | Filed | Satisfied for planning |
+| Stage 7 PBFAG | Filed and accepted | Filed | Satisfied for planning |
+| Stage 8 Implementation Plan | Filed and accepted | Filed | Satisfied for planning |
+| Stage 9 Builder Checklist | PASS for appointed builders | Checklist filed; candidate acknowledgements pending | Blocks build |
+| Stage 10 IAA Pre-Brief | Acknowledged by Foreman/builders; assurance/advisory recorded | Artifact filed; acknowledgements/advisory pending | Blocks build |
+| Stage 11 Builder Appointment | Formal appointed builders recorded | Scaffold filed; no builders appointed | Blocks build |
+
+---
+
+## 4. Build Authorization Blockers
+
+| Blocker ID | Blocker | Required Resolution Before Build |
+|---|---|---|
+| BUILD-ALP-BLOCK-001 | No named builders appointed | update Stage 11 with named builders and formal Foreman appointment |
+| BUILD-ALP-BLOCK-002 | Stage 9 candidate checklist PASS missing | record PASS for every appointed builder |
+| BUILD-ALP-BLOCK-003 | Stage 10 IAA acknowledgements missing | record Foreman and builder acknowledgements |
+| BUILD-ALP-BLOCK-004 | ASSURANCE-TOKEN / PHASE_A_ADVISORY missing | record token or advisory status before appointment/build |
+| BUILD-ALP-BLOCK-005 | Stage 2 UX Workflow & Wiring Spec carry-forward verification | verify/file before build or formally block build |
+| BUILD-ALP-BLOCK-006 | Stage 3 FRS carry-forward verification | verify/file before build or formally block build |
+| BUILD-ALP-BLOCK-007 | Stage 4 TRS carry-forward verification | verify/file before build or formally block build |
+| BUILD-ALP-BLOCK-008 | Stage 5 Architecture v0.2 carry-forward verification | verify/file before build or formally block build |
+| BUILD-ALP-BLOCK-009 | Requirement Registry carry-forward verification | verify/file before build or formally block build |
+| BUILD-ALP-BLOCK-010 | QA-ALP range acceptance unresolved | confirm module-local acceptance or canonical registration |
+| BUILD-ALP-BLOCK-011 | Runtime/Deployment Contract not filed | file contract before W0 begins |
+| BUILD-ALP-BLOCK-012 | Golden Path Verification Pack not filed | file pack before W0 begins |
+| BUILD-ALP-BLOCK-013 | Build tracker not initialized | create/update ALP build tracker before W0 begins |
+| BUILD-ALP-BLOCK-014 | Wave evidence folders not confirmed | confirm evidence path set before W0 begins |
+
+---
+
+## 5. Authorized Build Scope If Later Unblocked
+
+If all blockers are cleared and build is later authorized, the build scope is limited to the APGI Learning Portal V1 defined by upstream artifacts:
+
+- learner auth and role access;
+- invitation/manual/payment enrolment;
+- learner profile and private files;
+- dashboard and course cards;
+- course shell and read-only URL-module unit viewer;
+- progress and completion;
+- assessment submission and evidence upload;
+- AIMC Gateway AI evaluation;
+- human review;
+- certificates;
+- admin operations;
+- reports;
+- audit;
+- privacy, RLS, accessibility, deployment, and CWT evidence.
+
+Excluded without separate authorization:
+
+- SCORM/cmi5 runtime;
+- xAPI/LRS;
+- LTI;
+- Open Badges;
+- multi-tenant white-label;
+- AI tutor;
+- mobile/offline app;
+- pathway builder.
+
+---
+
+## 6. Build-to-Green Execution Constraints
+
+If build is later authorized, every wave must follow these constraints:
+
+- implement only approved Stage 8 wave scope;
+- use Stage 8 QA/Traceability Resolution for executable QA boundaries;
+- use Stage 9 Builder Checklist for builder-readiness obligations;
+- use Stage 10 IAA Pre-Brief for task acceptance criteria;
+- use Stage 11 Builder Appointment for assigned builder scope;
+- create and prove any required expansion RED suite before implementing expanded scope;
+- turn assigned RED tests GREEN;
+- preserve prior GREEN regression suites;
+- file evidence before handover;
+- pass all required merge gates before wave closure;
+- stop immediately on failing QA, security, privacy, deployment, evidence, or governance gate.
+
+---
+
+## 7. Wave Authorization Register
+
+No wave is authorized by this artifact.
+
+| Wave | Build Authorized? | Required Before Start | Current Status |
+|---|---|---|---|
+| W0 Foundation / Scaffold | No | Stage 11 appointment, build authorization, runtime/deployment contract, golden path pack | Blocked |
+| W1 Auth + Profile + Files | No | W0 closed GREEN and W1 builder appointed | Blocked |
+| W2 Dashboard + Course Shell + Unit Viewer | No | W1 closed GREEN and W2 builder appointed | Blocked |
+| W3 Progress + Completion | No | W2 closed GREEN and W3 builder appointed | Blocked |
+| W4 Enrolment + Payments | No | W1/W2 closed GREEN and W4 builder appointed | Blocked |
+| W5 Assessment Submission | No | W1/W3/W4 closed GREEN and W5 builder appointed | Blocked |
+| W6 AI Evaluation + Human Review | No | W5 closed GREEN and W6 builder appointed | Blocked |
+| W7 Certificates | No | W3/W6 closed GREEN and W7 builder appointed | Blocked |
+| W8 Admin Reports + Audit | No | W1-W7 closed GREEN and W8 builder appointed | Blocked |
+| W9 Deployment + CWT | No | W0-W8 closed GREEN and W9 builder appointed | Blocked |
+
+---
+
+## 8. Build Evidence Requirements If Later Authorized
+
+Before any wave can close, evidence must be filed for that wave.
+
+Minimum evidence classes:
+
+- CI/build/typecheck/test logs;
+- RED-to-GREEN delta summary;
+- screenshots or browser proof for user-visible workflows;
+- database migration proof where applicable;
+- RLS/security negative proof where applicable;
+- storage privacy proof where applicable;
+- payment webhook/idempotency proof where applicable;
+- AIMC request/response and failure-to-review proof where applicable;
+- certificate generation/download/audit proof where applicable;
+- deployment URL and CWT closure evidence for W9.
+
+No local-only proof is sufficient for deployment or final CWT closure.
+
+---
+
+## 9. Stage 12 Gate Checklist
+
+| Gate Item | Result | Reason |
+|---|---|---|
+| Stage 12 artifact exists | PASS when merged | This file |
+| Build scope recorded | PASS | Section 5 |
+| Build-to-Green constraints recorded | PASS | Section 6 |
+| Wave authorization register exists | PASS | Section 7 |
+| Evidence requirements recorded | PASS | Section 8 |
+| Stage 11 named builders appointed | FAIL | No builders appointed |
+| Stage 9 checklist PASS per appointed builder | FAIL | No appointed builders |
+| Stage 10 acknowledgements complete | FAIL | Pending |
+| ASSURANCE-TOKEN / PHASE_A_ADVISORY recorded | FAIL | Pending |
+| Runtime/Deployment Contract filed | FAIL | Pending |
+| Golden Path Verification Pack filed | FAIL | Pending |
+| Build authorized | NO | Blocked by failed gate items |
+
+---
+
+## 10. Stage 12 Decision
+
+```text
+Stage 12 Build Authorization: BLOCKED.
+Build / Implementation: BLOCKED.
+Reason: Stage 11 contains no actual appointed builders and required acknowledgement / assurance / readiness blockers remain open.
+```
+
+This artifact is complete as a blocked build-authorization scaffold. It does not authorize any implementation work.
+
+---
+
+## 11. Proxy Sign-Off
+
+I, ChatGPT acting as Product Owner / Foreman / Governance proxy at user request, record that this Stage 12 artifact defines the build-authorization gate, remaining blockers, authorized scope boundaries, execution constraints, wave authorization register, and evidence requirements.
+
+I do not authorize build or implementation.
+
+---
+
+## 12. Required Follow-Up Before Build Can Start
+
+To move from blocked scaffold to actual build authorization, complete all of the following:
+
+1. update Stage 11 with named builder appointments;
+2. complete Stage 9 checklist PASS evidence for appointed builders;
+3. complete Stage 10 IAA acknowledgements;
+4. record ASSURANCE-TOKEN or PHASE_A_ADVISORY;
+5. verify/file carry-forward Stage 2-5 and Requirement Registry artifacts;
+6. confirm QA-ALP range status;
+7. file Runtime/Deployment Contract;
+8. file Golden Path Verification Pack;
+9. initialize build tracker;
+10. issue explicit Foreman Build Authorization.
+
+Until then, build remains blocked.
+
+---
+
+## 13. Change History
+
+| Version | Date | Change Description | Changed By | Approval |
+|---|---|---|---|---|
+| 0.1 | 2026-06-11 | Initial blocked Stage 12 Build Authorization scaffold created after Stage 11 appointment-record scaffold merge. | ChatGPT acting as Product Owner / Foreman / Governance proxy | BLOCKED - no build authorization |


### PR DESCRIPTION
## Summary

Adds the Stage 12 Build Authorization scaffold for the APGI Learning Portal after Stage 11 Builder Appointment record was merged.

## Adds

- `modules/ALP/11-build/build-authorization.md`

## Governance status

This PR records the build authorization gate but intentionally keeps the build blocked.

Decision inside the artifact:

- Stage 12 Build Authorization: blocked
- Build / implementation: blocked
- Reason: Stage 11 contains no actual appointed builders and required acknowledgement / assurance / readiness blockers remain open

## Scaffold coverage

The scaffold defines:

- upstream gate status
- build authorization blockers
- authorized build scope boundaries if later unblocked
- build-to-green execution constraints
- wave authorization register
- build evidence requirements
- Stage 12 gate checklist
- required follow-up before build can start

## Build status

This PR does **not** authorize build or implementation.

Build remains blocked until named builders are appointed, Stage 9 and Stage 10 acknowledgements are complete, ASSURANCE-TOKEN / PHASE_A_ADVISORY is recorded, carry-forward artifacts are verified, Runtime/Deployment Contract and Golden Path Verification Pack are filed, and explicit Foreman Build Authorization is issued.