### PR TITLE
Add ALP WS-05 carry-forward artifact verification

### DIFF
--- a/modules/ALP/11-build/carry-forward-artifact-verification.md
+++ b/modules/ALP/11-build/carry-forward-artifact-verification.md
@@ -8,7 +8,7 @@
 | Module | ALP - APGI Learning Portal |
 | Workstream | WS-05 - Carry-Forward Artifact Verification |
 | Stage Context | Post-Stage 12 blocked build readiness remediation |
-| Version | 0.1 |
+| Version | 0.2 |
 | Status | Draft - verification filed; carry-forward blockers remain open |
 | Repository | APGI-cmy/Training |
 | Canonical Path | modules/ALP/11-build/carry-forward-artifact-verification.md |
@@ -43,7 +43,8 @@ Checks used:
 
 - direct fetch of expected canonical path where known;
 - repository search for ALP foundation artifacts and registry terms;
-- review of existing ALP module stage paths referenced by prior stages.
+- review of existing ALP module stage paths referenced by prior stages;
+- alignment with the QA-to-Red governance artifact expectations in `tests/qa-to-red/alp/governance-artifacts.spec.ts`.
 
 The expected Stage 2-5 and Requirement Registry artifacts were not found at the expected ALP module paths during this verification pass. This means they remain build-blocking until filed or their actual canonical paths are confirmed and linked.
 
@@ -54,10 +55,10 @@ The expected Stage 2-5 and Requirement Registry artifacts were not found at the 
 | Stage / Registry | Expected Path | Verification Result | Build Impact |
 |---|---|---|---|
 | Stage 2 - UX Workflow & Wiring Spec | modules/ALP/01-ux-workflow-wiring/ux-workflow-wiring-spec.md | Not found at expected path | Blocks appointment/build |
-| Stage 3 - FRS | modules/ALP/02-frs/frs.md | Not found at expected path | Blocks appointment/build |
-| Stage 4 - TRS | modules/ALP/03-trs/trs.md | Not found at expected path | Blocks appointment/build |
+| Stage 3 - FRS | modules/ALP/02-frs/functional-requirements.md | Not found at expected path | Blocks appointment/build |
+| Stage 4 - TRS | modules/ALP/03-trs/technical-requirements-specification.md | Not found at expected path | Blocks appointment/build |
 | Stage 5 - Architecture v0.2 | modules/ALP/04-architecture/architecture.md | Not found at expected path | Blocks appointment/build |
-| Requirement Registry | modules/ALP/requirement-registry.md or modules/ALP/04-architecture/requirement-registry.md | Not found at expected path | Blocks appointment/build |
+| Requirement Registry | modules/ALP/REQUIREMENT_REGISTRY.md | Not found at expected path | Blocks appointment/build |
 | QA-ALP Range Status | modules/ALP/05-qa-to-red/qa-catalog-alignment.md | Filed, but final ID governance remains to be confirmed in WS-06 | Blocks build until WS-06 completes |
 
 ---
@@ -68,7 +69,7 @@ The following ALP artifacts are known to be filed and do not need to be re-creat
 
 | Artifact | Path | Status |
 |---|---|---|
-| Stage 0 App Description | modules/ALP/00-app-description/APGI_LEARNING_PORTAL_APP_DESCRIPTION.md | Filed |
+| Stage 1 App Description | modules/ALP/00-app-description/APGI_LEARNING_PORTAL_APP_DESCRIPTION.md | Filed |
 | Stage 6 QA-to-Red | modules/ALP/05-qa-to-red/qa-to-red.md | Filed |
 | Stage 6 QA Catalog Alignment | modules/ALP/05-qa-to-red/qa-catalog-alignment.md | Filed |
 | Stage 6 RED Proof Report | modules/ALP/05-qa-to-red/red-proof-report.md | Filed |
@@ -102,7 +103,7 @@ The following ALP artifacts are known to be filed and do not need to be re-creat
 |---|---|
 | Required? | Yes |
 | Current Status | Missing or unverified on `main` |
-| Expected Path | modules/ALP/02-frs/frs.md |
+| Expected Path | modules/ALP/02-frs/functional-requirements.md |
 | Required Action | File the Stage 3 FRS at the expected path, or confirm the actual canonical path and update this verification record |
 | Build Impact | Blocks builder appointment and build authorization |
 
@@ -112,7 +113,7 @@ The following ALP artifacts are known to be filed and do not need to be re-creat
 |---|---|
 | Required? | Yes |
 | Current Status | Missing or unverified on `main` |
-| Expected Path | modules/ALP/03-trs/trs.md |
+| Expected Path | modules/ALP/03-trs/technical-requirements-specification.md |
 | Required Action | File the Stage 4 TRS at the expected path, or confirm the actual canonical path and update this verification record |
 | Build Impact | Blocks builder appointment and build authorization |
 
@@ -132,8 +133,8 @@ The following ALP artifacts are known to be filed and do not need to be re-creat
 |---|---|
 | Required? | Yes |
 | Current Status | Missing or unverified on `main` |
-| Expected Path | modules/ALP/requirement-registry.md or modules/ALP/04-architecture/requirement-registry.md |
-| Required Action | File the Requirement Registry at a canonical path, or confirm the actual canonical path and update this verification record |
+| Expected Path | modules/ALP/REQUIREMENT_REGISTRY.md |
+| Required Action | File the Requirement Registry at the QA-enforced canonical path, or confirm the actual canonical path and update this verification record |
 | Build Impact | Blocks builder appointment and build authorization |
 
 ### CF-ALP-006 - QA-ALP Range Status
@@ -158,6 +159,16 @@ The missing or unverified artifacts should be filed in the original pre-build se
 4. Stage 5 Architecture v0.2;
 5. Requirement Registry;
 6. WS-06 QA-ALP Range Status confirmation.
+
+Canonical filing targets:
+
+```text
+modules/ALP/01-ux-workflow-wiring/ux-workflow-wiring-spec.md
+modules/ALP/02-frs/functional-requirements.md
+modules/ALP/03-trs/technical-requirements-specification.md
+modules/ALP/04-architecture/architecture.md
+modules/ALP/REQUIREMENT_REGISTRY.md
+```
 
 If any artifact already exists in another branch or uploaded source, it should be copied into the ALP module path through a PR and linked back to this verification record.
 
@@ -215,3 +226,4 @@ It does not constitute Foreman/Governance sign-off and does not authorize builde
 | Version | Date | Change Description | Changed By | Approval |
 |---|---|---|---|---|
 | 0.1 | 2026-06-11 | Initial WS-05 carry-forward artifact verification filed after build readiness remediation plan merge. | AI-assisted draft (pending Foreman review) | Filed with failing carry-forward items; build remains blocked |
+| 0.2 | 2026-06-15 | Aligned FRS, TRS, and Requirement Registry paths with QA-to-Red governance artifact expectations and corrected App Description stage label to Stage 1. | AI-assisted draft (pending Foreman review) | Filed with failing carry-forward items; build remains blocked |

--- a/modules/ALP/11-build/carry-forward-artifact-verification.md
+++ b/modules/ALP/11-build/carry-forward-artifact-verification.md
@@ -1,0 +1,217 @@
+# APGI Learning Portal - WS-05 Carry-Forward Artifact Verification
+
+## Status Header
+
+| Field | Value |
+|---|---|
+| Artifact | Carry-Forward Artifact Verification |
+| Module | ALP - APGI Learning Portal |
+| Workstream | WS-05 - Carry-Forward Artifact Verification |
+| Stage Context | Post-Stage 12 blocked build readiness remediation |
+| Version | 0.1 |
+| Status | Draft - verification filed; carry-forward blockers remain open |
+| Repository | APGI-cmy/Training |
+| Canonical Path | modules/ALP/11-build/carry-forward-artifact-verification.md |
+| Prepared Date | 2026-06-11 |
+| Prepared By | AI-assisted draft (filed for review; requires Foreman/Governance human sign-off) |
+| Upstream Remediation Plan | modules/ALP/11-build/build-readiness-remediation-plan.md |
+| Build Authorized? | No |
+| Builder Appointment Authorized? | No |
+| Implementation Authorized? | No |
+
+---
+
+## 1. Purpose
+
+This WS-05 artifact verifies the carry-forward foundational ALP artifacts that must be present on `main` before builder appointment or build authorization can proceed.
+
+The verification target is the blocker set carried forward from Stage 7, Stage 8, Stage 9, Stage 10, Stage 11, and the blocked Stage 12 readiness record.
+
+This artifact does not authorize builder appointment, build, or implementation.
+
+---
+
+## 2. Verification Method
+
+The following checks were performed against the `APGI-cmy/Training` repository on `main` at base commit:
+
+```text
+d8634caba9a132db3df20e0060b31ba38b00295d
+```
+
+Checks used:
+
+- direct fetch of expected canonical path where known;
+- repository search for ALP foundation artifacts and registry terms;
+- review of existing ALP module stage paths referenced by prior stages.
+
+The expected Stage 2-5 and Requirement Registry artifacts were not found at the expected ALP module paths during this verification pass. This means they remain build-blocking until filed or their actual canonical paths are confirmed and linked.
+
+---
+
+## 3. Expected Artifact Paths
+
+| Stage / Registry | Expected Path | Verification Result | Build Impact |
+|---|---|---|---|
+| Stage 2 - UX Workflow & Wiring Spec | modules/ALP/01-ux-workflow-wiring/ux-workflow-wiring-spec.md | Not found at expected path | Blocks appointment/build |
+| Stage 3 - FRS | modules/ALP/02-frs/frs.md | Not found at expected path | Blocks appointment/build |
+| Stage 4 - TRS | modules/ALP/03-trs/trs.md | Not found at expected path | Blocks appointment/build |
+| Stage 5 - Architecture v0.2 | modules/ALP/04-architecture/architecture.md | Not found at expected path | Blocks appointment/build |
+| Requirement Registry | modules/ALP/requirement-registry.md or modules/ALP/04-architecture/requirement-registry.md | Not found at expected path | Blocks appointment/build |
+| QA-ALP Range Status | modules/ALP/05-qa-to-red/qa-catalog-alignment.md | Filed, but final ID governance remains to be confirmed in WS-06 | Blocks build until WS-06 completes |
+
+---
+
+## 4. Current Confirmed ALP Artifacts on Main
+
+The following ALP artifacts are known to be filed and do not need to be re-created by WS-05:
+
+| Artifact | Path | Status |
+|---|---|---|
+| Stage 0 App Description | modules/ALP/00-app-description/APGI_LEARNING_PORTAL_APP_DESCRIPTION.md | Filed |
+| Stage 6 QA-to-Red | modules/ALP/05-qa-to-red/qa-to-red.md | Filed |
+| Stage 6 QA Catalog Alignment | modules/ALP/05-qa-to-red/qa-catalog-alignment.md | Filed |
+| Stage 6 RED Proof Report | modules/ALP/05-qa-to-red/red-proof-report.md | Filed |
+| Stage 7 PBFAG | modules/ALP/06-pbfag/pbfag.md | Filed |
+| Stage 8 Implementation Plan | modules/ALP/07-implementation-plan/implementation-plan.md | Filed |
+| Stage 8 QA / Traceability Resolution | modules/ALP/07-implementation-plan/qa-and-traceability-resolution.md | Filed |
+| Stage 9 Builder Checklist | modules/ALP/08-builder-checklist/builder-checklist.md | Filed |
+| Stage 9 Review Resolution | modules/ALP/08-builder-checklist/builder-checklist-review-resolution.md | Filed |
+| Stage 10 IAA Pre-Brief | modules/ALP/09-iaa-pre-brief/iaa-pre-brief.md | Filed |
+| Stage 11 Builder Appointment Record | modules/ALP/10-builder-appointment/builder-appointment.md | Filed as scaffold; no actual appointment |
+| Stage 12 Blocked Build Authorization Record | modules/ALP/11-build/build-authorization.md | Filed as blocked readiness record |
+| Build Readiness Remediation Plan | modules/ALP/11-build/build-readiness-remediation-plan.md | Filed |
+
+---
+
+## 5. Missing / Unverified Carry-Forward Items
+
+### CF-ALP-001 - Stage 2 UX Workflow & Wiring Spec
+
+| Field | Value |
+|---|---|
+| Required? | Yes |
+| Current Status | Missing or unverified on `main` |
+| Expected Path | modules/ALP/01-ux-workflow-wiring/ux-workflow-wiring-spec.md |
+| Required Action | File the Stage 2 UX Workflow & Wiring Spec at the expected path, or confirm the actual canonical path and update this verification record |
+| Build Impact | Blocks builder appointment and build authorization |
+
+### CF-ALP-002 - Stage 3 FRS
+
+| Field | Value |
+|---|---|
+| Required? | Yes |
+| Current Status | Missing or unverified on `main` |
+| Expected Path | modules/ALP/02-frs/frs.md |
+| Required Action | File the Stage 3 FRS at the expected path, or confirm the actual canonical path and update this verification record |
+| Build Impact | Blocks builder appointment and build authorization |
+
+### CF-ALP-003 - Stage 4 TRS
+
+| Field | Value |
+|---|---|
+| Required? | Yes |
+| Current Status | Missing or unverified on `main` |
+| Expected Path | modules/ALP/03-trs/trs.md |
+| Required Action | File the Stage 4 TRS at the expected path, or confirm the actual canonical path and update this verification record |
+| Build Impact | Blocks builder appointment and build authorization |
+
+### CF-ALP-004 - Stage 5 Architecture v0.2
+
+| Field | Value |
+|---|---|
+| Required? | Yes |
+| Current Status | Missing or unverified on `main` |
+| Expected Path | modules/ALP/04-architecture/architecture.md |
+| Required Action | File the Stage 5 Architecture v0.2 at the expected path, or confirm the actual canonical path and update this verification record |
+| Build Impact | Blocks builder appointment and build authorization |
+
+### CF-ALP-005 - Requirement Registry
+
+| Field | Value |
+|---|---|
+| Required? | Yes |
+| Current Status | Missing or unverified on `main` |
+| Expected Path | modules/ALP/requirement-registry.md or modules/ALP/04-architecture/requirement-registry.md |
+| Required Action | File the Requirement Registry at a canonical path, or confirm the actual canonical path and update this verification record |
+| Build Impact | Blocks builder appointment and build authorization |
+
+### CF-ALP-006 - QA-ALP Range Status
+
+| Field | Value |
+|---|---|
+| Required? | Yes |
+| Current Status | Partially filed via Stage 6 QA Catalog Alignment; final governance status deferred to WS-06 |
+| Known Path | modules/ALP/05-qa-to-red/qa-catalog-alignment.md |
+| Required Action | Complete WS-06 to confirm module-local acceptance or canonical registration |
+| Build Impact | Blocks build authorization until WS-06 completes |
+
+---
+
+## 6. Recommended Filing Order for Missing Artifacts
+
+The missing or unverified artifacts should be filed in the original pre-build sequence:
+
+1. Stage 2 UX Workflow & Wiring Spec;
+2. Stage 3 FRS;
+3. Stage 4 TRS;
+4. Stage 5 Architecture v0.2;
+5. Requirement Registry;
+6. WS-06 QA-ALP Range Status confirmation.
+
+If any artifact already exists in another branch or uploaded source, it should be copied into the ALP module path through a PR and linked back to this verification record.
+
+---
+
+## 7. WS-05 Gate Checklist
+
+| Gate Item | Result | Reason |
+|---|---|---|
+| WS-05 artifact exists | FILED when merged | This file |
+| Stage 2 UX Workflow & Wiring Spec verified | FAIL | Missing or unverified on `main` |
+| Stage 3 FRS verified | FAIL | Missing or unverified on `main` |
+| Stage 4 TRS verified | FAIL | Missing or unverified on `main` |
+| Stage 5 Architecture v0.2 verified | FAIL | Missing or unverified on `main` |
+| Requirement Registry verified | FAIL | Missing or unverified on `main` |
+| QA-ALP range status ready for WS-06 | PARTIAL | Stage 6 alignment exists; final ID governance pending WS-06 |
+| Builder appointment authorized | NO | Carry-forward blockers remain |
+| Build authorized | NO | Carry-forward blockers remain |
+
+---
+
+## 8. WS-05 Decision
+
+```text
+WS-05 Carry-Forward Artifact Verification: FILED WITH FAILING CARRY-FORWARD ITEMS.
+Builder Appointment: BLOCKED.
+Build Authorization: BLOCKED.
+Implementation: BLOCKED.
+```
+
+This artifact completes the WS-05 verification pass by identifying unresolved carry-forward blockers. It does not clear those blockers.
+
+---
+
+## 9. Drafting Note (AI-assisted)
+
+This verification record was drafted with AI assistance at user request and is filed for review.
+It does not constitute Foreman/Governance sign-off and does not authorize builder appointment, build, or implementation.
+
+---
+
+## 10. Next Required Actions
+
+1. File or confirm Stage 2 UX Workflow & Wiring Spec.
+2. File or confirm Stage 3 FRS.
+3. File or confirm Stage 4 TRS.
+4. File or confirm Stage 5 Architecture v0.2.
+5. File or confirm Requirement Registry.
+6. Proceed to WS-06 QA-ALP Range Status only after missing carry-forward artifacts are resolved or formally accepted as still-blocking.
+
+---
+
+## 11. Change History
+
+| Version | Date | Change Description | Changed By | Approval |
+|---|---|---|---|---|
+| 0.1 | 2026-06-11 | Initial WS-05 carry-forward artifact verification filed after build readiness remediation plan merge. | AI-assisted draft (pending Foreman review) | Filed with failing carry-forward items; build remains blocked |


### PR DESCRIPTION
## Summary

Adds WS-05 Carry-Forward Artifact Verification for the APGI Learning Portal build-readiness remediation flow.

## Adds

- `modules/ALP/11-build/carry-forward-artifact-verification.md`

## Governance status

This PR does **not** authorize builder appointment, build, or implementation.

Decision inside the artifact:

- WS-05 Carry-Forward Artifact Verification: filed with failing carry-forward items
- Builder appointment: blocked
- Build authorization: blocked
- Implementation: blocked

## Verification result

The artifact records that the following carry-forward items remain missing or unverified on `main`:

- Stage 2 UX Workflow & Wiring Spec
- Stage 3 FRS
- Stage 4 TRS
- Stage 5 Architecture v0.2
- Requirement Registry

QA-ALP range status is marked partial because Stage 6 QA Catalog Alignment exists, but final ID governance remains pending WS-06.

## Build status

Build remains blocked until the missing/unverified carry-forward artifacts are filed or their actual canonical paths are confirmed and linked, and the remaining remediation workstreams are completed.