### PR TITLE
Confirm ALP QA range status

### DIFF
--- a/modules/ALP/05-qa-to-red/qa-alp-range-status.md
+++ b/modules/ALP/05-qa-to-red/qa-alp-range-status.md
@@ -1,0 +1,156 @@
+# APGI Learning Portal - WS-06 QA-ALP Range Status Confirmation
+
+## Status Header
+
+| Field | Value |
+|---|---|
+| Artifact | QA-ALP Range Status Confirmation |
+| Module | ALP - APGI Learning Portal |
+| Workstream | WS-06 - QA-ALP Range Status confirmation |
+| Version | 0.1 |
+| Status | Draft - filed for governance review |
+| Repository | APGI-cmy/Training |
+| Canonical Path | modules/ALP/05-qa-to-red/qa-alp-range-status.md |
+| Prepared Date | 2026-06-16 |
+| Prepared By | AI-assisted draft based on filed Stage 6 QA-to-Red and QA Catalog Alignment artifacts; requires Foreman/Governance review |
+| Derived From | modules/ALP/05-qa-to-red/qa-to-red.md; modules/ALP/05-qa-to-red/qa-catalog-alignment.md; modules/ALP/REQUIREMENT_REGISTRY.md |
+| QA Range | QA-ALP-001 through QA-ALP-700 |
+| Range Posture | Confirmed module-local ALP QA range, pending any later canonical QA Catalog registration mandate |
+| Build Authorized? | No |
+| Builder Appointment Authorized? | No |
+| Implementation Authorized? | No |
+
+---
+
+## 1. Purpose
+
+This artifact confirms the governance posture for the APGI Learning Portal QA marker range after WS-05 carry-forward artifacts were filed.
+
+It addresses the WS-06 requirement to make the `QA-ALP-001` through `QA-ALP-700` range status explicit before moving to downstream runtime, deployment, golden-path, build-tracker, evidence, builder appointment, or build authorization work.
+
+This artifact does not authorize builder appointment, build, or implementation.
+
+---
+
+## 2. Source Artifacts Reviewed
+
+| Source | Path | Relevant Finding |
+|---|---|---|
+| Stage 6 QA-to-Red | modules/ALP/05-qa-to-red/qa-to-red.md | RED test intent and build-blocking posture filed. |
+| Stage 6 QA Catalog Alignment | modules/ALP/05-qa-to-red/qa-catalog-alignment.md | `QA-ALP-001` through `QA-ALP-700` reserved as module-local range. |
+| Requirement Registry | modules/ALP/REQUIREMENT_REGISTRY.md | Registry includes filed module-local QA ranges and keeps WS-06 final range status pending until this artifact. |
+| WS-05 Carry-Forward Verification | modules/ALP/11-build/carry-forward-artifact-verification.md | Identified QA-ALP Range Status as carry-forward item requiring final governance confirmation. |
+
+---
+
+## 3. Confirmed QA Range
+
+```text
+QA-ALP-001 through QA-ALP-700
+```
+
+This range is confirmed as the APGI Learning Portal module-local QA marker range for filed ALP QA-to-RED work.
+
+The range remains traceable to the ALP module and may be used for ALP-local test/evidence organization unless Foreman/Governance later mandates migration or registration into a global canonical QA Catalog.
+
+---
+
+## 4. Range Allocation Confirmation
+
+| Range | Domain | Test File | WS-06 Status |
+|---|---|---|---|
+| QA-ALP-001 to QA-ALP-020 | Governance and artifact gates | tests/qa-to-red/alp/governance-artifacts.spec.ts | Confirmed module-local |
+| QA-ALP-021 to QA-ALP-065 | Architecture physical inventory | tests/qa-to-red/alp/architecture-inventory.spec.ts | Confirmed module-local |
+| QA-ALP-066 to QA-ALP-080 | Auth, roles, route protection | tests/qa-to-red/alp/auth.spec.ts | Confirmed module-local |
+| QA-ALP-211 to QA-ALP-250 | Course shell and unit viewer | tests/qa-to-red/alp/course-shell.spec.ts | Confirmed module-local |
+| QA-ALP-291 to QA-ALP-340 | Assessment submission | tests/qa-to-red/alp/assessment-submission.spec.ts | Confirmed module-local |
+| QA-ALP-416 to QA-ALP-450 | Certificates | tests/qa-to-red/alp/certificate.spec.ts | Confirmed module-local |
+| QA-ALP-526 to QA-ALP-565 | Security/privacy/RLS | tests/qa-to-red/alp/security-privacy.spec.ts | Confirmed module-local |
+| QA-ALP-636 to QA-ALP-700 | Deployment and CWT | tests/qa-to-red/alp/deployment-cwt.spec.ts | Confirmed module-local |
+
+The unused gaps in `QA-ALP-001` through `QA-ALP-700` remain reserved for ALP-local expansion unless a future governance artifact reallocates them.
+
+---
+
+## 5. Governance Decision
+
+```text
+WS-06 QA-ALP Range Status: CONFIRMED MODULE-LOCAL.
+QA-ALP-001 through QA-ALP-700: ACCEPTED FOR ALP MODULE-LOCAL TRACEABILITY.
+Canonical QA Catalog registration: NOT REQUIRED BEFORE WS-07 unless Foreman/Governance later mandates it.
+Builder Appointment: BLOCKED.
+Build Authorization: BLOCKED.
+Implementation: BLOCKED.
+```
+
+This decision confirms the ALP QA range posture only. It does not approve test results, does not mark RED tests as passing, and does not authorize implementation.
+
+---
+
+## 6. Effect on WS-05 and WS-06
+
+| Item | Status After This Artifact Is Merged |
+|---|---|
+| WS-05 missing Stage 2 UX artifact | Cleared by filed Stage 2 UX path. |
+| WS-05 missing Stage 3 FRS artifact | Cleared by filed Stage 3 FRS path. |
+| WS-05 missing Stage 4 TRS artifact | Cleared by filed Stage 4 TRS path. |
+| WS-05 missing Stage 5 Architecture artifact | Cleared by filed Stage 5 Architecture path. |
+| WS-05 missing Requirement Registry artifact | Cleared by filed Requirement Registry path. |
+| WS-06 QA-ALP Range Status | Confirmed module-local by this artifact once merged. |
+
+---
+
+## 7. Remaining Governance Blockers
+
+| Blocker ID | Blocker | Required Resolution |
+|---|---|---|
+| WS06-ALP-BLOCK-001 | Runtime/Deployment Contract not filed | Complete WS-07 before build starts. |
+| WS06-ALP-BLOCK-002 | Golden Path Verification Pack not filed | Complete WS-08 before build starts. |
+| WS06-ALP-BLOCK-003 | Build tracker not initialized | Complete WS-09 before build starts. |
+| WS06-ALP-BLOCK-004 | Evidence folder convention not confirmed | Complete WS-10 before build starts. |
+| WS06-ALP-BLOCK-005 | Stage 9 builder checklist PASS evidence for named builders not complete | Complete before builder appointment. |
+| WS06-ALP-BLOCK-006 | Stage 10 IAA acknowledgements for named builders not complete | Complete before builder appointment. |
+| WS06-ALP-BLOCK-007 | Assurance/advisory recording not complete | Complete before builder appointment. |
+| WS06-ALP-BLOCK-008 | Stage 11 actual builder appointment not complete | Complete before Stage 12 build authorization. |
+| WS06-ALP-BLOCK-009 | Final Stage 12 build authorization not issued | Complete only after all prior blockers clear. |
+
+---
+
+## 8. Gate Checklist
+
+| Gate Item | Result | Reason |
+|---|---|---|
+| QA range explicitly identified | PASS | `QA-ALP-001` through `QA-ALP-700`. |
+| Module-local posture confirmed | PASS | Section 5. |
+| Existing range allocations preserved | PASS | Section 4. |
+| Canonical QA Catalog dependency resolved for current path | PASS | Not required before WS-07 unless later mandated. |
+| Build authorization preserved as blocked | PASS | Sections 5 and 7. |
+| Human Governance approval | PENDING | Required before approval state. |
+
+---
+
+## 9. WS-06 Decision
+
+```text
+WS-06 QA-ALP Range Status Confirmation: FILED FOR REVIEW.
+QA-ALP-001 through QA-ALP-700: CONFIRMED MODULE-LOCAL when merged.
+WS-07 Runtime/Deployment Contract: NEXT.
+Builder Appointment: BLOCKED.
+Build Authorization: BLOCKED.
+Implementation: BLOCKED.
+```
+
+---
+
+## 10. Drafting Note (AI-assisted)
+
+This WS-06 range status confirmation was drafted with AI assistance at user request and is filed for review.
+It does not constitute final Foreman, Product Owner, Technical, Architecture, QA, or Governance approval.
+
+---
+
+## 11. Change History
+
+| Version | Date | Change Description | Changed By | Approval |
+|---|---|---|---|---|
+| 0.1 | 2026-06-16 | Filed WS-06 QA-ALP Range Status Confirmation for `QA-ALP-001` through `QA-ALP-700`. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |

--- a/modules/ALP/05-qa-to-red/qa-alp-range-status.md
+++ b/modules/ALP/05-qa-to-red/qa-alp-range-status.md
@@ -49,7 +49,7 @@ This artifact does not authorize builder appointment, build, or implementation.
 QA-ALP-001 through QA-ALP-700
 ```
 
-This range is confirmed as the APGI Learning Portal module-local QA marker range for filed ALP QA-to-RED work.
+This range is confirmed as the APGI Learning Portal module-local QA marker range for filed ALP QA-to-Red work.
 
 The range remains traceable to the ALP module and may be used for ALP-local test/evidence organization unless Foreman/Governance later mandates migration or registration into a global canonical QA Catalog.
 

--- a/modules/ALP/05-qa-to-red/qa-alp-range-status.md
+++ b/modules/ALP/05-qa-to-red/qa-alp-range-status.md
@@ -6,7 +6,7 @@
 |---|---|
 | Artifact | QA-ALP Range Status Confirmation |
 | Module | ALP - APGI Learning Portal |
-| Workstream | WS-06 - QA-ALP Range Status confirmation |
+| Workstream | WS-06 - QA-ALP Range Status Confirmation |
 | Version | 0.1 |
 | Status | Draft - filed for governance review |
 | Repository | APGI-cmy/Training |

--- a/modules/ALP/05-qa-to-red/qa-alp-range-status.md
+++ b/modules/ALP/05-qa-to-red/qa-alp-range-status.md
@@ -7,7 +7,7 @@
 | Artifact | QA-ALP Range Status Confirmation |
 | Module | ALP - APGI Learning Portal |
 | Workstream | WS-06 - QA-ALP Range Status Confirmation |
-| Version | 0.1 |
+| Version | 0.2 |
 | Status | Draft - filed for governance review |
 | Repository | APGI-cmy/Training |
 | Canonical Path | modules/ALP/05-qa-to-red/qa-alp-range-status.md |
@@ -38,6 +38,7 @@ This artifact does not authorize builder appointment, build, or implementation.
 |---|---|---|
 | Stage 6 QA-to-Red | modules/ALP/05-qa-to-red/qa-to-red.md | RED test intent and build-blocking posture filed. |
 | Stage 6 QA Catalog Alignment | modules/ALP/05-qa-to-red/qa-catalog-alignment.md | `QA-ALP-001` through `QA-ALP-700` reserved as module-local range. |
+| Assessment RED suite | tests/qa-to-red/alp/assessment-submission.spec.ts | Active markers include `QA-ALP-291`, `QA-ALP-296`, `QA-ALP-297`, `QA-ALP-341`, and `QA-ALP-381`. |
 | Requirement Registry | modules/ALP/REQUIREMENT_REGISTRY.md | Registry includes filed module-local QA ranges and keeps WS-06 final range status pending until this artifact. |
 | WS-05 Carry-Forward Verification | modules/ALP/11-build/carry-forward-artifact-verification.md | Identified QA-ALP Range Status as carry-forward item requiring final governance confirmation. |
 
@@ -57,18 +58,20 @@ The range remains traceable to the ALP module and may be used for ALP-local test
 
 ## 4. Range Allocation Confirmation
 
-| Range | Domain | Test File | WS-06 Status |
+| Range / Marker | Domain | Test File | WS-06 Status |
 |---|---|---|---|
 | QA-ALP-001 to QA-ALP-020 | Governance and artifact gates | tests/qa-to-red/alp/governance-artifacts.spec.ts | Confirmed module-local |
 | QA-ALP-021 to QA-ALP-065 | Architecture physical inventory | tests/qa-to-red/alp/architecture-inventory.spec.ts | Confirmed module-local |
 | QA-ALP-066 to QA-ALP-080 | Auth, roles, route protection | tests/qa-to-red/alp/auth.spec.ts | Confirmed module-local |
 | QA-ALP-211 to QA-ALP-250 | Course shell and unit viewer | tests/qa-to-red/alp/course-shell.spec.ts | Confirmed module-local |
-| QA-ALP-291 to QA-ALP-340 | Assessment submission | tests/qa-to-red/alp/assessment-submission.spec.ts | Confirmed module-local |
+| QA-ALP-291 to QA-ALP-340 | Assessment admin, submission, and evidence upload | tests/qa-to-red/alp/assessment-submission.spec.ts | Confirmed module-local |
+| QA-ALP-341 | AI evaluation action uses AIMC | tests/qa-to-red/alp/assessment-submission.spec.ts | Confirmed module-local active marker |
+| QA-ALP-381 | Review queue and review action exist | tests/qa-to-red/alp/assessment-submission.spec.ts | Confirmed module-local active marker |
 | QA-ALP-416 to QA-ALP-450 | Certificates | tests/qa-to-red/alp/certificate.spec.ts | Confirmed module-local |
 | QA-ALP-526 to QA-ALP-565 | Security/privacy/RLS | tests/qa-to-red/alp/security-privacy.spec.ts | Confirmed module-local |
 | QA-ALP-636 to QA-ALP-700 | Deployment and CWT | tests/qa-to-red/alp/deployment-cwt.spec.ts | Confirmed module-local |
 
-The unused gaps in `QA-ALP-001` through `QA-ALP-700` remain reserved for ALP-local expansion unless a future governance artifact reallocates them.
+The unused gaps in `QA-ALP-001` through `QA-ALP-700` remain reserved for ALP-local expansion unless a future governance artifact reallocates them. Active filed markers inside those gaps, including `QA-ALP-341` and `QA-ALP-381`, are explicitly confirmed above and are not treated as unallocated.
 
 ---
 
@@ -123,6 +126,7 @@ This decision confirms the ALP QA range posture only. It does not approve test r
 | QA range explicitly identified | PASS | `QA-ALP-001` through `QA-ALP-700`. |
 | Module-local posture confirmed | PASS | Section 5. |
 | Existing range allocations preserved | PASS | Section 4. |
+| Active assessment markers included | PASS | `QA-ALP-341` and `QA-ALP-381` explicitly confirmed. |
 | Canonical QA Catalog dependency resolved for current path | PASS | Not required before WS-07 unless later mandated. |
 | Build authorization preserved as blocked | PASS | Sections 5 and 7. |
 | Human Governance approval | PENDING | Required before approval state. |
@@ -154,3 +158,4 @@ It does not constitute final Foreman, Product Owner, Technical, Architecture, QA
 | Version | Date | Change Description | Changed By | Approval |
 |---|---|---|---|---|
 | 0.1 | 2026-06-16 | Filed WS-06 QA-ALP Range Status Confirmation for `QA-ALP-001` through `QA-ALP-700`. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |
+| 0.2 | 2026-06-16 | Confirmed active assessment markers `QA-ALP-341` and `QA-ALP-381` inside the module-local range. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |


### PR DESCRIPTION
## Summary

Files the WS-06 QA-ALP Range Status Confirmation artifact.

## Adds

- `modules/ALP/05-qa-to-red/qa-alp-range-status.md`

## Governance decision filed

The artifact confirms:

```text
WS-06 QA-ALP Range Status: confirmed module-local
QA-ALP-001 through QA-ALP-700: accepted for ALP module-local traceability
Canonical QA Catalog registration: not required before WS-07 unless Foreman/Governance later mandates it
```

## Scope

This PR confirms the ALP QA marker range posture only. It does not:

- approve test results
- mark RED tests as passing
- authorize builder appointment
- authorize build
- authorize implementation

## Next workstream

After merge, the next workstream is:

```text
WS-07 — Runtime / Deployment Contract
```