### PR TITLE
File ALP evidence folder convention

### DIFF
--- a/modules/ALP/11-build/evidence/README.md
+++ b/modules/ALP/11-build/evidence/README.md
@@ -7,13 +7,13 @@
 | Artifact | Evidence Folder Convention |
 | Module | ALP - APGI Learning Portal |
 | Workstream | WS-10 - Evidence Folder Convention |
-| Version | 0.1 |
+| Version | 0.2 |
 | Status | Draft - filed for governance review |
 | Repository | APGI-cmy/Training |
 | Canonical Path | modules/ALP/11-build/evidence/README.md |
 | Prepared Date | 2026-06-17 |
 | Prepared By | AI-assisted draft based on filed ALP build-readiness remediation artifacts; requires Foreman/Governance/QA review |
-| Derived From | WS-08 Golden Path Verification Pack; WS-09 Build Progress Tracker; WS-07 Runtime / Deployment Contract; WS-06 QA-ALP Range Status Confirmation |
+| Derived From | WS-08 Golden Path Verification Pack; WS-09 Build Progress Tracker; WS-07 Runtime / Deployment Contract; WS-06 QA-ALP Range Status Confirmation; Stage 8 Implementation Plan; Stage 9 Builder Checklist |
 | Build Authorized? | No |
 | Builder Appointment Authorized? | No |
 | Implementation Authorized? | No |
@@ -38,7 +38,7 @@ The canonical ALP build evidence root is:
 modules/ALP/11-build/evidence/
 ```
 
-This README is the index and convention file for that evidence root.
+This README is the convention file for the evidence root. The canonical roll-up evidence index is `modules/ALP/11-build/evidence/index.md`, which must be created before or during the first authorized build-wave evidence PR.
 
 All future build-wave evidence must be filed under this root unless a later approved governance artifact explicitly changes the evidence location.
 
@@ -46,25 +46,25 @@ All future build-wave evidence must be filed under this root unless a later appr
 
 ## 3. Required Folder Structure
 
-Future evidence must use this structure:
+Future evidence must use this structure, aligned to the existing Stage 8 implementation plan and Stage 9 builder checklist wave definitions:
 
 ```text
 modules/ALP/11-build/evidence/
 ├── README.md
 ├── index.md
-├── W0-runtime-baseline/
-├── W1-auth-roles/
-├── W2-enrolment-payment/
-├── W3-course-shell/
-├── W4-assessment-submission/
-├── W5-aimc-review/
-├── W6-certificates/
-├── W7-admin-reporting/
-├── W8-security-privacy/
+├── W0-foundation-scaffold/
+├── W1-auth-profile-files/
+├── W2-dashboard-course-shell/
+├── W3-progress-completion/
+├── W4-enrolment-payments/
+├── W5-assessment-submission/
+├── W6-ai-review/
+├── W7-certificates/
+├── W8-admin-reports-audit/
 └── W9-deployment-cwt/
 ```
 
-`index.md` must be created before or during the first authorized build-wave evidence PR. It must provide a roll-up table linking each evidence file to its wave, QA marker(s), PR, check status, and closure decision.
+`index.md` must provide a roll-up table linking each evidence file to its wave, QA marker(s), PR, check status, and closure decision.
 
 The wave folders above may remain absent until build is authorized and evidence is produced, but their names are reserved by this convention.
 
@@ -74,16 +74,16 @@ The wave folders above may remain absent until build is authorized and evidence 
 
 | Wave | Folder | Evidence Purpose |
 |---|---|---|
-| W0 | `W0-runtime-baseline/` | Runtime baseline, app shell, environment posture, health/readiness evidence |
-| W1 | `W1-auth-roles/` | Auth, roles, route protection, denied-path evidence |
-| W2 | `W2-enrolment-payment/` | Invite, paid enrolment, admin enrolment, payment webhook/idempotency evidence |
-| W3 | `W3-course-shell/` | Dashboard, course shell, unit navigation, external URL recovery evidence |
-| W4 | `W4-assessment-submission/` | Progress, assessment unlock, submission, evidence upload evidence |
-| W5 | `W5-aimc-review/` | AIMC Gateway evaluation, failure handling, review queue evidence |
-| W6 | `W6-certificates/` | Certificate eligibility, generation, storage/privacy evidence |
-| W7 | `W7-admin-reporting/` | Admin reports, exports, audit evidence |
-| W8 | `W8-security-privacy/` | RLS/privacy, cross-learner denial, secret/privacy posture evidence |
-| W9 | `W9-deployment-cwt/` | Preview URL, protected preview access, CWT route evidence, final closure pack |
+| W0 | `W0-foundation-scaffold/` | Foundation/scaffold, tooling, environment, repo structure, base app shell, Supabase config skeleton, health/readiness evidence |
+| W1 | `W1-auth-profile-files/` | Auth, roles, protected layouts, profile, private profile file upload, denied-path evidence |
+| W2 | `W2-dashboard-course-shell/` | Learner dashboard, course cards, course shell, sidebar, read-only URL-module unit viewer evidence |
+| W3 | `W3-progress-completion/` | Progress events, learner progress, module/course completion, next-action evidence |
+| W4 | `W4-enrolment-payments/` | Invitation, manual enrolment, Stripe checkout/webhook/idempotency, payment audit evidence |
+| W5 | `W5-assessment-submission/` | Assessment definitions, rubrics, attempts, written/evidence submission evidence |
+| W6 | `W6-ai-review/` | AIMC Gateway adapter, AI states, reviewer queue, final outcomes evidence |
+| W7 | `W7-certificates/` | Certificate eligibility, generation, storage, download, certificate event evidence |
+| W8 | `W8-admin-reports-audit/` | Admin operations, reports, audit UI, report filter evidence |
+| W9 | `W9-deployment-cwt/` | Deployed integrated LMS, CWT evidence package, preview URL proof, final proof |
 
 ---
 
@@ -99,7 +99,7 @@ Examples:
 
 ```text
 20260617-W1-QA-ALP-066-screenshot-learner-dashboard-denied.png
-20260617-W4-GP-ALP-007-test-output-assessment-submission.md
+20260617-W5-GP-ALP-007-test-output-assessment-submission.md
 20260617-W9-GP-ALP-012-cwt-preview-route-smoke.md
 ```
 
@@ -259,6 +259,7 @@ Implementation: BLOCKED.
 | Screenshot/video rules defined | PASS | Section 9. |
 | Test output/log rules defined | PASS | Section 10. |
 | Wave closure evidence rules defined | PASS | Section 11. |
+| Wave mapping aligned to Stage 8/9 plan | PASS | Sections 3 and 4 use the existing W0-W9 wave definitions. |
 | Human Governance/QA approval | PENDING | Required before approval state. |
 | Build authorized | NO | Builder/build/implementation remain blocked. |
 
@@ -289,3 +290,4 @@ It does not constitute final Foreman, Product Owner, Technical, Architecture, QA
 | Version | Date | Change Description | Changed By | Approval |
 |---|---|---|---|---|
 | 0.1 | 2026-06-17 | Filed WS-10 Evidence Folder Convention for ALP. | AI-assisted draft (pending Foreman/Governance/QA review) | Filed for review; build remains blocked |
+| 0.2 | 2026-06-17 | Clarified README vs index roles and aligned W0-W9 evidence folders to the existing Stage 8/9 wave plan. | AI-assisted draft (pending Foreman/Governance/QA review) | Filed for review; build remains blocked |

--- a/modules/ALP/11-build/evidence/README.md
+++ b/modules/ALP/11-build/evidence/README.md
@@ -1,0 +1,291 @@
+# APGI Learning Portal - WS-10 Evidence Folder Convention
+
+## Status Header
+
+| Field | Value |
+|---|---|
+| Artifact | Evidence Folder Convention |
+| Module | ALP - APGI Learning Portal |
+| Workstream | WS-10 - Evidence Folder Convention |
+| Version | 0.1 |
+| Status | Draft - filed for governance review |
+| Repository | APGI-cmy/Training |
+| Canonical Path | modules/ALP/11-build/evidence/README.md |
+| Prepared Date | 2026-06-17 |
+| Prepared By | AI-assisted draft based on filed ALP build-readiness remediation artifacts; requires Foreman/Governance/QA review |
+| Derived From | WS-08 Golden Path Verification Pack; WS-09 Build Progress Tracker; WS-07 Runtime / Deployment Contract; WS-06 QA-ALP Range Status Confirmation |
+| Build Authorized? | No |
+| Builder Appointment Authorized? | No |
+| Implementation Authorized? | No |
+
+---
+
+## 1. Purpose
+
+This artifact defines the canonical evidence folder convention for future ALP build-wave evidence, CWT evidence, test output, screenshots, logs, traceability proofs, and closure records.
+
+It satisfies WS-10 from the ALP build-readiness remediation flow by defining where evidence must be placed and how it must be named and linked before any future build wave can close.
+
+This artifact does not create runtime evidence, execute CWT, authorize builder appointment, authorize build, or authorize implementation.
+
+---
+
+## 2. Evidence Root
+
+The canonical ALP build evidence root is:
+
+```text
+modules/ALP/11-build/evidence/
+```
+
+This README is the index and convention file for that evidence root.
+
+All future build-wave evidence must be filed under this root unless a later approved governance artifact explicitly changes the evidence location.
+
+---
+
+## 3. Required Folder Structure
+
+Future evidence must use this structure:
+
+```text
+modules/ALP/11-build/evidence/
+├── README.md
+├── index.md
+├── W0-runtime-baseline/
+├── W1-auth-roles/
+├── W2-enrolment-payment/
+├── W3-course-shell/
+├── W4-assessment-submission/
+├── W5-aimc-review/
+├── W6-certificates/
+├── W7-admin-reporting/
+├── W8-security-privacy/
+└── W9-deployment-cwt/
+```
+
+`index.md` must be created before or during the first authorized build-wave evidence PR. It must provide a roll-up table linking each evidence file to its wave, QA marker(s), PR, check status, and closure decision.
+
+The wave folders above may remain absent until build is authorized and evidence is produced, but their names are reserved by this convention.
+
+---
+
+## 4. Wave Folder Contract
+
+| Wave | Folder | Evidence Purpose |
+|---|---|---|
+| W0 | `W0-runtime-baseline/` | Runtime baseline, app shell, environment posture, health/readiness evidence |
+| W1 | `W1-auth-roles/` | Auth, roles, route protection, denied-path evidence |
+| W2 | `W2-enrolment-payment/` | Invite, paid enrolment, admin enrolment, payment webhook/idempotency evidence |
+| W3 | `W3-course-shell/` | Dashboard, course shell, unit navigation, external URL recovery evidence |
+| W4 | `W4-assessment-submission/` | Progress, assessment unlock, submission, evidence upload evidence |
+| W5 | `W5-aimc-review/` | AIMC Gateway evaluation, failure handling, review queue evidence |
+| W6 | `W6-certificates/` | Certificate eligibility, generation, storage/privacy evidence |
+| W7 | `W7-admin-reporting/` | Admin reports, exports, audit evidence |
+| W8 | `W8-security-privacy/` | RLS/privacy, cross-learner denial, secret/privacy posture evidence |
+| W9 | `W9-deployment-cwt/` | Preview URL, protected preview access, CWT route evidence, final closure pack |
+
+---
+
+## 5. Evidence File Naming Rules
+
+Evidence files must use this naming pattern:
+
+```text
+<YYYYMMDD>-<wave>-<qa-marker-or-path-id>-<evidence-type>-<short-description>.<ext>
+```
+
+Examples:
+
+```text
+20260617-W1-QA-ALP-066-screenshot-learner-dashboard-denied.png
+20260617-W4-GP-ALP-007-test-output-assessment-submission.md
+20260617-W9-GP-ALP-012-cwt-preview-route-smoke.md
+```
+
+Approved evidence type tokens:
+
+| Token | Meaning |
+|---|---|
+| `screenshot` | Static browser/UI screenshot |
+| `video` | Browser/session recording |
+| `test-output` | Test output, command result, or test summary |
+| `log` | Sanitized runtime/build/application log excerpt |
+| `cwt` | Click-walk-through evidence |
+| `audit` | Audit trail proof |
+| `report` | Report/export proof |
+| `trace` | Traceability proof |
+| `decision` | Review/approval/closure decision |
+
+---
+
+## 6. Evidence Index Requirements
+
+`modules/ALP/11-build/evidence/index.md` must include this table when created:
+
+| Wave | Evidence File | QA Marker(s) | Golden / Negative Path | Environment | PR / Commit | Check Status | Reviewer / Owner | Closure Status | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+
+Every build-wave evidence PR must update both:
+
+1. `modules/ALP/11-build/evidence/index.md`; and
+2. `modules/ALP/BUILD_PROGRESS_TRACKER.md`.
+
+The tracker must link to the evidence file(s) and reflect merge/check/blocker status for the affected W0-W9 row.
+
+---
+
+## 7. Environment and URL Recording Rules
+
+Every CWT or deployed-environment evidence record must state:
+
+- environment name;
+- URL or protected preview URL reference;
+- whether deployment is preview, protected preview, production, or local;
+- access method used;
+- timestamp;
+- actor/test identity;
+- route/path exercised;
+- expected result;
+- actual result;
+- pass/fail state;
+- unresolved issue link if failed.
+
+Protected preview access links must not be recorded if they expose private or long-lived credentials. Record only the evidence-safe reference required to reproduce or audit the run.
+
+---
+
+## 8. Secret and Private Data Exclusion Rules
+
+Evidence must never include:
+
+- secret keys;
+- service role keys;
+- payment provider secrets;
+- webhook signing secrets;
+- AIMC Gateway API keys;
+- certificate signing secrets;
+- production learner personal data;
+- private learner documents;
+- uncontrolled public links to learner-private material;
+- raw database URLs or connection strings;
+- session cookies;
+- bearer tokens;
+- full auth headers.
+
+If an evidence artifact accidentally includes prohibited material, it must not be merged. A redacted replacement must be produced before evidence can count toward closure.
+
+---
+
+## 9. Screenshot and Video Rules
+
+Screenshots and videos must:
+
+- show the route or state under test;
+- avoid real personal data;
+- use test identities only;
+- avoid browser extensions or unrelated tabs when possible;
+- avoid exposing auth/session tokens in URL bars or devtools;
+- be linked from `index.md` and the tracker;
+- include QA marker or path ID in the filename.
+
+---
+
+## 10. Test Output and Log Rules
+
+Test output and log evidence must:
+
+- include command or tool context when safe;
+- include pass/fail summary;
+- include relevant QA marker(s);
+- be redacted for secrets and private data;
+- avoid excessive raw logs when a concise evidence summary is sufficient;
+- link to CI/check results when available.
+
+---
+
+## 11. Closure Requirements
+
+No wave may close unless the evidence folder contains or links to:
+
+- all required evidence for that wave;
+- relevant QA markers;
+- CWT or browser evidence where required by WS-08;
+- test/check results where required;
+- unresolved blocker/risk status;
+- reviewer or governance disposition;
+- updated `BUILD_PROGRESS_TRACKER.md` row.
+
+Wave evidence may be incomplete, failed, or blocked, but it must be labeled honestly. Failed evidence must not be presented as closure evidence.
+
+---
+
+## 12. Current Status
+
+```text
+WS-10 Evidence Folder Convention: FILED FOR REVIEW.
+Evidence folder convention: DEFINED FOR REVIEW.
+Evidence artifacts: NOT YET PRODUCED.
+Build waves W0-W9: BLOCKED.
+Builder Appointment: BLOCKED.
+Build Authorization: BLOCKED.
+Implementation: BLOCKED.
+```
+
+---
+
+## 13. Remaining Governance Blockers
+
+| Blocker ID | Blocker | Required Resolution |
+|---|---|---|
+| WS10-ALP-BLOCK-001 | Stage 9 named-builder PASS evidence incomplete | Complete before builder appointment. |
+| WS10-ALP-BLOCK-002 | Stage 10 acknowledgements/advisory incomplete | Complete before builder appointment. |
+| WS10-ALP-BLOCK-003 | Stage 11 actual builder appointment incomplete | Complete only after Stage 9/10/advisory prerequisites. |
+| WS10-ALP-BLOCK-004 | Final Stage 12 build authorization missing | Complete only after all prior blockers clear. |
+| WS10-ALP-BLOCK-005 | Build evidence not produced | Build evidence remains impossible until build is authorized. |
+
+---
+
+## 14. Gate Checklist
+
+| Gate Item | Result | Reason |
+|---|---|---|
+| Evidence root defined | PASS | Section 2. |
+| W0-W9 folder convention defined | PASS | Sections 3 and 4. |
+| Evidence naming rules defined | PASS | Section 5. |
+| Evidence index requirements defined | PASS | Section 6. |
+| CWT URL/environment recording rules defined | PASS | Section 7. |
+| Secret/private-data exclusions defined | PASS | Section 8. |
+| Screenshot/video rules defined | PASS | Section 9. |
+| Test output/log rules defined | PASS | Section 10. |
+| Wave closure evidence rules defined | PASS | Section 11. |
+| Human Governance/QA approval | PENDING | Required before approval state. |
+| Build authorized | NO | Builder/build/implementation remain blocked. |
+
+---
+
+## 15. WS-10 Decision
+
+```text
+WS-10 Evidence Folder Convention: FILED FOR REVIEW.
+WS-10 evidence convention: DEFINED FOR REVIEW.
+Next governance blockers: Stage 9 named-builder PASS evidence, Stage 10 acknowledgements/advisory, Stage 11 appointment, final Stage 12 build authorization.
+Builder Appointment: BLOCKED.
+Build Authorization: BLOCKED.
+Implementation: BLOCKED.
+```
+
+---
+
+## 16. Drafting Note (AI-assisted)
+
+This Evidence Folder Convention was drafted with AI assistance at user request and is filed for review.
+It does not constitute final Foreman, Product Owner, Technical, Architecture, QA, or Governance approval.
+
+---
+
+## 17. Change History
+
+| Version | Date | Change Description | Changed By | Approval |
+|---|---|---|---|---|
+| 0.1 | 2026-06-17 | Filed WS-10 Evidence Folder Convention for ALP. | AI-assisted draft (pending Foreman/Governance/QA review) | Filed for review; build remains blocked |

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -2,21 +2,21 @@
 
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
-**Last Updated**: 2026-06-16  
-**Updated By**: WS-08 Golden Path Verification Pack filing and ALP progress tracker initialization  
-> **Classification**: ACTIVE - PRE-BUILD REMEDIATION IN PROGRESS - WS-08 FILED FOR REVIEW - BUILD BLOCKED  
+**Last Updated**: 2026-06-17  
+**Updated By**: WS-10 Evidence Folder Convention filing after PR #63 merge  
+> **Classification**: ACTIVE - PRE-BUILD REMEDIATION IN PROGRESS - WS-10 FILED FOR REVIEW - BUILD BLOCKED  
 > **Repository**: APGI-cmy/Training  
 > **Tracker Location**: `modules/ALP/BUILD_PROGRESS_TRACKER.md`  
-> **Current Workstream**: WS-08 - Golden Path Verification Pack  
-> **Next Workstream**: WS-10 - Evidence Folder Convention
+> **Current Workstream**: WS-10 - Evidence Folder Convention  
+> **Next Workstream**: WS-02 - Stage 9 Builder Checklist PASS Evidence
 
 ---
 
 ## Current Executive Status
 
-ALP is in pre-build remediation. Stages 1 through 6 have now been filed at canonical module paths, the Requirement Registry is filed, WS-06 QA range status is confirmed module-local, and WS-07 Runtime / Deployment Contract is filed.
+ALP is in pre-build remediation. Stages 1 through 6 have been filed at canonical module paths, the Requirement Registry is filed, WS-06 QA range status is confirmed module-local, WS-07 Runtime / Deployment Contract is filed, and PR #63 merged the WS-08 Golden Path Verification Pack plus the initialized WS-09 Build Progress Tracker.
 
-WS-08 Golden Path Verification Pack is being filed for review in the same PR that initializes this tracker.
+WS-10 Evidence Folder Convention is being filed for review in the current PR.
 
 No builder has been appointed. No build has been authorized. No implementation has been authorized.
 
@@ -24,8 +24,8 @@ No builder has been appointed. No build has been authorized. No implementation h
 Builder Appointment: BLOCKED
 Build Authorization: BLOCKED
 Implementation: BLOCKED
-Current stage/workstream: WS-08 Golden Path Verification Pack filed for review
-Next stage/workstream: WS-10 - Evidence Folder Convention
+Current stage/workstream: WS-10 Evidence Folder Convention filed for review
+Next stage/workstream after WS-10 merge: WS-02 - Stage 9 Builder Checklist PASS Evidence
 ```
 
 ---
@@ -43,9 +43,9 @@ Next stage/workstream: WS-10 - Evidence Folder Convention
 | Requirement Registry | FILED FOR REVIEW | `modules/ALP/REQUIREMENT_REGISTRY.md` |
 | WS-06 QA-ALP Range Status | CONFIRMED MODULE-LOCAL | `modules/ALP/05-qa-to-red/qa-alp-range-status.md` |
 | WS-07 Runtime / Deployment Contract | FILED FOR REVIEW | `modules/ALP/11-build/runtime-deployment-contract.md` |
-| WS-08 Golden Path Verification Pack | FILED FOR REVIEW IN CURRENT PR | `modules/ALP/11-build/golden-path-verification-pack.md` |
-| WS-09 Build Tracker | INITIALIZED IN CURRENT PR | `modules/ALP/BUILD_PROGRESS_TRACKER.md` |
-| WS-10 Evidence Folder Convention | NOT STARTED | Pending |
+| WS-08 Golden Path Verification Pack | MERGED / ACCEPTED ON MAIN | `modules/ALP/11-build/golden-path-verification-pack.md` |
+| WS-09 Build Tracker | INITIALIZED / ACCEPTED ON MAIN | `modules/ALP/BUILD_PROGRESS_TRACKER.md` |
+| WS-10 Evidence Folder Convention | FILED FOR REVIEW IN CURRENT PR | `modules/ALP/11-build/evidence/README.md` |
 | Stage 9 Builder Checklist | FILED BUT NOT PASS-FINALIZED FOR NAMED BUILDERS | `modules/ALP/08-builder-checklist/builder-checklist.md` |
 | Stage 10 IAA Pre-Brief | FILED BUT ACKNOWLEDGEMENTS/ADVISORY STILL BLOCKING | `modules/ALP/09-iaa-pre-brief/iaa-pre-brief.md` |
 | Stage 11 Builder Appointment | BLOCKED | `modules/ALP/10-builder-appointment/builder-appointment.md` |
@@ -150,7 +150,7 @@ QA-ALP-001 through QA-ALP-700
 ---
 
 ### WS-08: Golden Path Verification Pack
-**Status**: [x] FILED FOR REVIEW IN CURRENT PR  
+**Status**: [x] MERGED / ACCEPTED ON MAIN  
 **Location**: `modules/ALP/11-build/`  
 **Key Artifacts**:
 - [x] `golden-path-verification-pack.md`
@@ -166,7 +166,7 @@ QA-ALP-001 through QA-ALP-700
 ---
 
 ### WS-09: Build Tracker Initialization / Ongoing Maintenance
-**Status**: [x] INITIALIZED IN CURRENT PR  
+**Status**: [x] INITIALIZED / ACCEPTED ON MAIN  
 **Location**: `modules/ALP/`  
 **Key Artifacts**:
 - [x] `BUILD_PROGRESS_TRACKER.md`
@@ -175,26 +175,26 @@ QA-ALP-001 through QA-ALP-700
 
 #### W0-W9 Build Wave Status Table
 
-This table satisfies WS-09 by recording wave status rows, evidence link columns, merge/check status columns, and blocker/risk columns. All waves remain blocked until WS-10, Stage 9/10/11, and final build authorization gates clear.
+This table records wave status rows, evidence link columns, merge/check status columns, and blocker/risk columns. All waves remain blocked until WS-10 is accepted on main, Stage 9/10/11 prerequisites are complete, and final build authorization clears.
 
 | Wave | Planned Scope | Status | Evidence Link(s) | Merge / PR Status | Check Status | Blocker / Risk |
 |---|---|---|---|---|---|---|
-| W0 | Runtime baseline, repo/app shell, environment contract alignment, health/readiness skeleton | BLOCKED - not authorized | Pending | No PR | No checks run | Build authorization blocked; WS-10 evidence convention missing; no appointed builder |
+| W0 | Runtime baseline, repo/app shell, environment contract alignment, health/readiness skeleton | BLOCKED - not authorized | Pending | No PR | No checks run | Build authorization blocked; WS-10 pending merge; no appointed builder |
 | W1 | Auth, roles, protected routes, learner/admin/reviewer access boundaries | BLOCKED - not authorized | Pending | No PR | No checks run | Builder appointment blocked; RED-to-GREEN not authorized |
 | W2 | Learner enrolment flows: invite, paid enrolment, admin enrolment, payment idempotency | BLOCKED - not authorized | Pending | No PR | No checks run | Payment sandbox/secrets not authorized; build blocked |
 | W3 | Dashboard, course shell, module/unit navigation, external URL unit handling | BLOCKED - not authorized | Pending | No PR | No checks run | Build blocked; CWT evidence not yet executable |
-| W4 | Progress tracking, assessment unlock, assessment submission, evidence upload | BLOCKED - not authorized | Pending | No PR | No checks run | Storage/evidence convention pending; build blocked |
+| W4 | Progress tracking, assessment unlock, assessment submission, evidence upload | BLOCKED - not authorized | Pending | No PR | No checks run | Storage/evidence convention pending merge; build blocked |
 | W5 | AIMC Gateway evaluation, failure handling, human review queue, reviewer final decision | BLOCKED - not authorized | Pending | No PR | No checks run | AIMC runtime secrets not authorized; build blocked |
 | W6 | Certificate eligibility, certificate generation, artifact privacy controls | BLOCKED - not authorized | Pending | No PR | No checks run | Certificate runtime/signing secret not authorized; build blocked |
-| W7 | Admin reports, exports, audit views, payment/admin review surfaces | BLOCKED - not authorized | Pending | No PR | No checks run | Admin evidence convention pending; build blocked |
+| W7 | Admin reports, exports, audit views, payment/admin review surfaces | BLOCKED - not authorized | Pending | No PR | No checks run | Admin evidence convention pending merge; build blocked |
 | W8 | Security/privacy hardening, role-denied paths, cross-learner denial, private storage checks | BLOCKED - not authorized | Pending | No PR | No checks run | RLS/security evidence not executable before build authorization |
-| W9 | Deployment/CWT evidence, preview URL proof, final wave evidence packaging, handover readiness | BLOCKED - not authorized | Pending | No PR | No checks run | WS-08/WS-10 and final build authorization required; production promotion blocked |
+| W9 | Deployment/CWT evidence, preview URL proof, final wave evidence packaging, handover readiness | BLOCKED - not authorized | Pending | No PR | No checks run | WS-10 and final build authorization required; production promotion blocked |
 
 #### Wave Closure Rule
 
 No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR REVIEW`, or `CLOSED` until all of the following are true:
 
-- WS-10 Evidence Folder Convention is filed and accepted;
+- WS-10 Evidence Folder Convention is accepted on main;
 - Stage 9 named-builder checklist PASS evidence is complete;
 - Stage 10 acknowledgements/advisory evidence is complete;
 - Stage 11 builder appointment is complete;
@@ -205,13 +205,21 @@ No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR RE
 ---
 
 ### WS-10: Evidence Folder Convention
-**Status**: [ ] NOT STARTED  
-**Expected Location**: `modules/ALP/11-build/evidence/` or other approved canonical evidence path  
-**Required Before Build**:
-- [ ] Evidence folder convention
-- [ ] CWT evidence naming rules
-- [ ] Screenshot/video/log/test-output storage rules
-- [ ] Secret/private-data exclusion rules
+**Status**: [x] FILED FOR REVIEW IN CURRENT PR  
+**Expected Location**: `modules/ALP/11-build/evidence/`  
+**Key Artifacts**:
+- [x] `modules/ALP/11-build/evidence/README.md`
+
+**Convention Coverage**:
+- [x] Evidence root
+- [x] W0-W9 evidence folder naming
+- [x] Evidence file naming rules
+- [x] Evidence index requirements
+- [x] CWT URL/environment recording rules
+- [x] Secret/private-data exclusion rules
+- [x] Screenshot/video rules
+- [x] Test output/log rules
+- [x] Wave closure evidence requirements
 
 ---
 
@@ -260,12 +268,13 @@ No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR RE
 - [x] `build-readiness-remediation-plan.md`
 - [x] `carry-forward-artifact-verification.md`
 - [x] `runtime-deployment-contract.md`
-- [x] `golden-path-verification-pack.md` - current PR
+- [x] `golden-path-verification-pack.md`
+- [x] `evidence/README.md` - current PR
 
 **Stage 12 cannot begin until**:
-- [ ] WS-08 is merged and reviewed
-- [ ] WS-09 tracker is current and accepted
-- [ ] WS-10 evidence convention is filed
+- [x] WS-08 is merged and reviewed
+- [x] WS-09 tracker is current and accepted
+- [ ] WS-10 evidence convention is merged and accepted
 - [ ] Stage 9 builder checklist is pass-finalized for named builder(s)
 - [ ] Stage 10 acknowledgements/advisory are complete
 - [ ] Stage 11 builder appointment is complete
@@ -277,29 +286,27 @@ No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR RE
 
 | Blocker ID | Blocker | Current Status | Required Next Action |
 |---|---|---|---|
-| ALP-BLOCK-001 | WS-08 Golden Path Verification Pack not merged | In current PR | Review and merge WS-08 artifact |
-| ALP-BLOCK-002 | WS-09 tracker not yet accepted on main | In current PR | Review and merge tracker |
-| ALP-BLOCK-003 | WS-10 evidence folder convention missing | Open | File evidence convention artifact |
-| ALP-BLOCK-004 | Stage 9 named-builder PASS evidence incomplete | Open | Complete builder checklist finalization |
-| ALP-BLOCK-005 | Stage 10 acknowledgements/advisory incomplete | Open | Complete IAA/advisory evidence |
-| ALP-BLOCK-006 | Stage 11 actual builder appointment incomplete | Open | Appoint builder only after prerequisites clear |
-| ALP-BLOCK-007 | Stage 12 final build authorization missing | Open | Issue only after all blockers clear |
+| ALP-BLOCK-001 | WS-10 evidence folder convention not merged | In current PR | Review and merge WS-10 artifact |
+| ALP-BLOCK-002 | Stage 9 named-builder PASS evidence incomplete | Open | Complete builder checklist finalization |
+| ALP-BLOCK-003 | Stage 10 acknowledgements/advisory incomplete | Open | Complete IAA/advisory evidence |
+| ALP-BLOCK-004 | Stage 11 actual builder appointment incomplete | Open | Appoint builder only after prerequisites clear |
+| ALP-BLOCK-005 | Stage 12 final build authorization missing | Open | Issue only after all blockers clear |
 
 ---
 
 ## Immediate Next Action
 
 ```text
-Review and merge the WS-08 Golden Path Verification Pack and ALP Build Progress Tracker PR.
+Review and merge the WS-10 Evidence Folder Convention and ALP Build Progress Tracker update PR.
 ```
 
 After this PR merges, the next workstream is:
 
 ```text
-WS-10 - Evidence Folder Convention
+WS-02 - Stage 9 Builder Checklist PASS Evidence
 ```
 
-The tracker itself is now initialized and must be kept current as each remaining blocker changes.
+The tracker itself must continue to be kept current as each remaining blocker changes.
 
 ---
 
@@ -324,3 +331,4 @@ No percentage-complete claim is made because ALP has not entered authorized buil
 |---|---|---|---|---|
 | 0.1 | 2026-06-16 | Initialized ALP build progress tracker alongside WS-08 Golden Path Verification Pack. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |
 | 0.2 | 2026-06-17 | Added required W0-W9 wave status table with evidence, merge/check status, and blocker/risk columns. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |
+| 0.3 | 2026-06-17 | Updated tracker after PR #63 merge and filed WS-10 Evidence Folder Convention for review. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -175,20 +175,20 @@ QA-ALP-001 through QA-ALP-700
 
 #### W0-W9 Build Wave Status Table
 
-This table records wave status rows, evidence link columns, merge/check status columns, and blocker/risk columns. All waves remain blocked until WS-10 is accepted on main, Stage 9/10/11 prerequisites are complete, and final build authorization clears.
+This table records wave status rows, evidence link columns, merge/check status columns, and blocker/risk columns. Wave IDs and scope align to the existing Stage 8 implementation plan and Stage 9 builder checklist. All waves remain blocked until WS-10 is accepted on main, Stage 9/10/11 prerequisites are complete, and final build authorization clears.
 
 | Wave | Planned Scope | Status | Evidence Link(s) | Merge / PR Status | Check Status | Blocker / Risk |
 |---|---|---|---|---|---|---|
-| W0 | Runtime baseline, repo/app shell, environment contract alignment, health/readiness skeleton | BLOCKED - not authorized | Pending | No PR | No checks run | Build authorization blocked; WS-10 pending merge; no appointed builder |
-| W1 | Auth, roles, protected routes, learner/admin/reviewer access boundaries | BLOCKED - not authorized | Pending | No PR | No checks run | Builder appointment blocked; RED-to-GREEN not authorized |
-| W2 | Learner enrolment flows: invite, paid enrolment, admin enrolment, payment idempotency | BLOCKED - not authorized | Pending | No PR | No checks run | Payment sandbox/secrets not authorized; build blocked |
-| W3 | Dashboard, course shell, module/unit navigation, external URL unit handling | BLOCKED - not authorized | Pending | No PR | No checks run | Build blocked; CWT evidence not yet executable |
-| W4 | Progress tracking, assessment unlock, assessment submission, evidence upload | BLOCKED - not authorized | Pending | No PR | No checks run | Storage/evidence convention pending merge; build blocked |
-| W5 | AIMC Gateway evaluation, failure handling, human review queue, reviewer final decision | BLOCKED - not authorized | Pending | No PR | No checks run | AIMC runtime secrets not authorized; build blocked |
-| W6 | Certificate eligibility, certificate generation, artifact privacy controls | BLOCKED - not authorized | Pending | No PR | No checks run | Certificate runtime/signing secret not authorized; build blocked |
-| W7 | Admin reports, exports, audit views, payment/admin review surfaces | BLOCKED - not authorized | Pending | No PR | No checks run | Admin evidence convention pending merge; build blocked |
-| W8 | Security/privacy hardening, role-denied paths, cross-learner denial, private storage checks | BLOCKED - not authorized | Pending | No PR | No checks run | RLS/security evidence not executable before build authorization |
-| W9 | Deployment/CWT evidence, preview URL proof, final wave evidence packaging, handover readiness | BLOCKED - not authorized | Pending | No PR | No checks run | WS-10 and final build authorization required; production promotion blocked |
+| W0 | Foundation / Scaffold: tooling, env, repo structure, base app shell, Supabase config skeleton | BLOCKED - not authorized | Pending | No PR | No checks run | Build authorization blocked; WS-10 pending merge; no appointed builder |
+| W1 | Auth + Profile + Files: auth, roles, protected layouts, profile, private profile file upload | BLOCKED - not authorized | Pending | No PR | No checks run | Builder appointment blocked; RED-to-GREEN not authorized |
+| W2 | Dashboard + Course Shell + Unit Viewer: learner dashboard, course cards, shell, sidebar, read-only URL-module unit viewer | BLOCKED - not authorized | Pending | No PR | No checks run | Build blocked; CWT evidence not yet executable |
+| W3 | Progress + Completion: progress events, learner progress, module/course completion, next action | BLOCKED - not authorized | Pending | No PR | No checks run | Progress evidence not executable before build authorization |
+| W4 | Enrolment + Payments: invitation, manual enrolment, checkout/webhook/idempotency | BLOCKED - not authorized | Pending | No PR | No checks run | Payment sandbox/secrets not authorized; build blocked |
+| W5 | Assessment Submission: assessment definitions, rubrics, attempts, written/evidence submission | BLOCKED - not authorized | Pending | No PR | No checks run | Storage/evidence convention pending merge; build blocked |
+| W6 | AI Evaluation + Human Review: AIMC Gateway adapter, AI states, reviewer queue, final outcomes | BLOCKED - not authorized | Pending | No PR | No checks run | AIMC runtime secrets not authorized; build blocked |
+| W7 | Certificates: eligibility, generation, storage, download, certificate events | BLOCKED - not authorized | Pending | No PR | No checks run | Certificate runtime/signing secret not authorized; build blocked |
+| W8 | Admin Reports + Audit: admin operations, reports, audit UI, report filters | BLOCKED - not authorized | Pending | No PR | No checks run | Admin/report evidence not executable before build authorization |
+| W9 | Deployment + CWT: deployed integrated LMS, CWT evidence package, final proof | BLOCKED - not authorized | Pending | No PR | No checks run | WS-10 and final build authorization required; production promotion blocked |
 
 #### Wave Closure Rule
 
@@ -212,7 +212,7 @@ No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR RE
 
 **Convention Coverage**:
 - [x] Evidence root
-- [x] W0-W9 evidence folder naming
+- [x] W0-W9 evidence folder naming aligned to existing Stage 8/9 wave definitions
 - [x] Evidence file naming rules
 - [x] Evidence index requirements
 - [x] CWT URL/environment recording rules
@@ -332,3 +332,4 @@ No percentage-complete claim is made because ALP has not entered authorized buil
 | 0.1 | 2026-06-16 | Initialized ALP build progress tracker alongside WS-08 Golden Path Verification Pack. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |
 | 0.2 | 2026-06-17 | Added required W0-W9 wave status table with evidence, merge/check status, and blocker/risk columns. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |
 | 0.3 | 2026-06-17 | Updated tracker after PR #63 merge and filed WS-10 Evidence Folder Convention for review. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |
+| 0.4 | 2026-06-17 | Aligned W0-W9 tracker rows to the existing Stage 8 implementation plan and Stage 9 builder checklist wave definitions. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |


### PR DESCRIPTION
## Summary

Files the WS-10 Evidence Folder Convention and updates the ALP build progress tracker after PR #63 merge.

## Adds

- `modules/ALP/11-build/evidence/README.md`

## Updates

- `modules/ALP/BUILD_PROGRESS_TRACKER.md`

## WS-10 scope

The Evidence Folder Convention defines:

- canonical ALP evidence root
- W0-W9 evidence folder naming
- evidence file naming rules
- evidence index requirements
- CWT URL/environment recording rules
- secret/private-data exclusion rules
- screenshot/video rules
- test output/log rules
- wave closure evidence requirements

## Tracker update

The tracker now reflects:

- PR #63 merged
- WS-08 Golden Path Verification Pack accepted on main
- WS-09 Build Tracker initialized/accepted on main
- WS-10 Evidence Folder Convention filed in this PR
- next workstream after merge: WS-02 Stage 9 Builder Checklist PASS Evidence

## Governance status

This PR does **not** authorize builder appointment, build, implementation, CODE_PASS, FUNCTIONAL_PASS, or CWT_PASS.

## Next workstream after merge

```text
WS-02 — Stage 9 Builder Checklist PASS Evidence
```