### PR TITLE
File ALP Stage 9 builder PASS evidence register

### DIFF
--- a/modules/ALP/08-builder-checklist/stage9-builder-pass-evidence.md
+++ b/modules/ALP/08-builder-checklist/stage9-builder-pass-evidence.md
@@ -7,7 +7,7 @@
 | Artifact | Stage 9 Builder Checklist PASS Evidence Register |
 | Module | ALP - APGI Learning Portal |
 | Workstream | WS-02 - Stage 9 Builder Checklist PASS Evidence |
-| Version | 0.1 |
+| Version | 0.2 |
 | Status | Filed as blocking evidence register - no builder PASS claim |
 | Repository | APGI-cmy/Training |
 | Canonical Path | modules/ALP/08-builder-checklist/stage9-builder-pass-evidence.md |
@@ -35,6 +35,7 @@ After reviewing the filed Stage 9 Builder Checklist, no actual builder candidate
 | Source | Finding |
 |---|---|
 | `modules/ALP/08-builder-checklist/builder-checklist.md` | Candidate register contains BC-ALP-001 through BC-ALP-010, all with `Builder / Agent` set to `To be assigned`, `Contract Current?` set to `Pending`, and `Checklist Result` set to `Pending`. |
+| `modules/ALP/08-builder-checklist/builder-checklist.md` | Universal checks require Stage 8 QA/Traceability acknowledgement, Architecture/TRS/FRS understanding, no-scope-deviation acknowledgement, dependency statements, protocol compliance, and Foreman role-fit decision. |
 | `modules/ALP/11-build/build-readiness-remediation-plan.md` | WS-02 requires Stage 9 Builder Checklist PASS evidence for every proposed builder and blocks appointment/build until complete. |
 | `modules/ALP/BUILD_PROGRESS_TRACKER.md` | Stage 9 named-builder PASS evidence remains an active blocker. |
 
@@ -66,15 +67,20 @@ Every proposed builder candidate must have all of the following before WS-02 can
 | WS02-EV-004 | Stage 6 QA-to-Red acknowledgement | Candidate acknowledgement evidence |
 | WS02-EV-005 | Stage 7 PBFAG acknowledgement | Candidate acknowledgement evidence |
 | WS02-EV-006 | Stage 8 Implementation Plan acknowledgement | Candidate acknowledgement evidence |
-| WS02-EV-007 | WS-07 Runtime / Deployment Contract acknowledgement, if assigned runtime/deployment work | Candidate acknowledgement evidence |
-| WS02-EV-008 | WS-08 Golden Path Verification Pack acknowledgement | Candidate acknowledgement evidence |
-| WS02-EV-009 | WS-10 Evidence Folder Convention acknowledgement | Candidate acknowledgement evidence |
-| WS02-EV-010 | RED QA suite understanding acknowledgement | Candidate acknowledgement evidence |
-| WS02-EV-011 | STOP-AND-FIX and merge-gate compliance acknowledgement | Candidate acknowledgement evidence |
-| WS02-EV-012 | Evidence filing responsibility acknowledgement | Candidate acknowledgement evidence |
-| WS02-EV-013 | No unresolved dependency blocker for assigned wave(s) | Candidate dependency statement |
-| WS02-EV-014 | Foreman role-fit decision | Foreman/Governance decision record |
-| WS02-EV-015 | Checklist result set to PASS | Updated Stage 9 checklist |
+| WS02-EV-007 | Stage 8 QA/Traceability Resolution acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-008 | WS-07 Runtime / Deployment Contract acknowledgement, if assigned runtime/deployment work | Candidate acknowledgement evidence |
+| WS02-EV-009 | WS-08 Golden Path Verification Pack acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-010 | WS-10 Evidence Folder Convention acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-011 | RED QA suite understanding acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-012 | Architecture, TRS, and FRS understanding for assigned scope | Candidate acknowledgement evidence |
+| WS02-EV-013 | STOP-AND-FIX and merge-gate compliance acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-014 | Evidence filing responsibility acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-015 | No scope deviation without Foreman approval acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-016 | No unresolved dependency blocker for assigned wave(s) | Candidate dependency statement |
+| WS02-EV-017 | Candidate has no unresolved review warnings or blockers | Warning/blocker review evidence |
+| WS02-EV-018 | Builder understands build remains blocked until Stage 12 authorization | Appointment-boundary acknowledgement |
+| WS02-EV-019 | Foreman role-fit decision | Foreman/Governance decision record |
+| WS02-EV-020 | Checklist result set to PASS | Updated Stage 9 checklist |
 
 ---
 
@@ -123,10 +129,11 @@ The later PR must:
 
 1. name the builder(s);
 2. link current contract(s);
-3. record acknowledgements;
-4. record Foreman role-fit decision(s);
-5. set each applicable candidate row to PASS;
-6. update the tracker blocker state.
+3. record all required acknowledgements listed in Section 4;
+4. record dependency/blocker statements;
+5. record Foreman role-fit decision(s);
+6. set each applicable candidate row to PASS;
+7. update the tracker blocker state.
 
 ---
 
@@ -138,6 +145,9 @@ The later PR must:
 | Builder candidates named | BLOCKED | Current candidates are `To be assigned`. |
 | Contracts current | BLOCKED | Current rows are `Pending`. |
 | Candidate acknowledgements complete | BLOCKED | No acknowledgements recorded. |
+| Stage 8 QA/Traceability acknowledgement captured | BLOCKED | No acknowledgements recorded. |
+| Architecture/TRS/FRS understanding captured | BLOCKED | No acknowledgements recorded. |
+| Scope-deviation acknowledgement captured | BLOCKED | No acknowledgements recorded. |
 | Foreman role-fit decisions recorded | BLOCKED | No decisions recorded. |
 | Checklist PASS evidence for every proposed builder | BLOCKED | No candidate has PASS evidence. |
 | Build authorization preserved as blocked | PASS | No build authorization is granted. |
@@ -168,3 +178,4 @@ This WS-02 evidence register was drafted with AI assistance at user request and 
 | Version | Date | Change Description | Changed By | Approval |
 |---|---|---|---|---|
 | 0.1 | 2026-06-17 | Filed WS-02 Stage 9 Builder Checklist PASS Evidence Register as a blocking-evidence record because no named builder PASS evidence exists. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; builder/build remain blocked |
+| 0.2 | 2026-06-18 | Added missing mandatory Stage 9 evidence items for QA/Traceability, Architecture/TRS/FRS understanding, scope-deviation acknowledgement, unresolved-warning check, and Stage 12 boundary acknowledgement. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; builder/build remain blocked |

--- a/modules/ALP/08-builder-checklist/stage9-builder-pass-evidence.md
+++ b/modules/ALP/08-builder-checklist/stage9-builder-pass-evidence.md
@@ -1,0 +1,170 @@
+# APGI Learning Portal - WS-02 Stage 9 Builder Checklist PASS Evidence Register
+
+## Status Header
+
+| Field | Value |
+|---|---|
+| Artifact | Stage 9 Builder Checklist PASS Evidence Register |
+| Module | ALP - APGI Learning Portal |
+| Workstream | WS-02 - Stage 9 Builder Checklist PASS Evidence |
+| Version | 0.1 |
+| Status | Filed as blocking evidence register - no builder PASS claim |
+| Repository | APGI-cmy/Training |
+| Canonical Path | modules/ALP/08-builder-checklist/stage9-builder-pass-evidence.md |
+| Prepared Date | 2026-06-17 |
+| Prepared By | AI-assisted draft based on filed Stage 9 Builder Checklist and ALP remediation tracker; requires Foreman/Governance review |
+| Derived From | modules/ALP/08-builder-checklist/builder-checklist.md; modules/ALP/11-build/build-readiness-remediation-plan.md; modules/ALP/BUILD_PROGRESS_TRACKER.md |
+| Builder Appointment Authorized? | No |
+| Build Authorized? | No |
+| Implementation Authorized? | No |
+
+---
+
+## 1. Purpose
+
+This artifact records the WS-02 Stage 9 Builder Checklist PASS Evidence state for ALP.
+
+The remediation plan requires WS-02 to record checklist PASS evidence for every proposed builder before Stage 11 builder appointment and Stage 12 build authorization may proceed.
+
+After reviewing the filed Stage 9 Builder Checklist, no actual builder candidate is currently named and no candidate-specific PASS evidence exists. This artifact therefore does not claim PASS. It records the missing evidence and the exact requirements needed to clear WS-02.
+
+---
+
+## 2. Source Review
+
+| Source | Finding |
+|---|---|
+| `modules/ALP/08-builder-checklist/builder-checklist.md` | Candidate register contains BC-ALP-001 through BC-ALP-010, all with `Builder / Agent` set to `To be assigned`, `Contract Current?` set to `Pending`, and `Checklist Result` set to `Pending`. |
+| `modules/ALP/11-build/build-readiness-remediation-plan.md` | WS-02 requires Stage 9 Builder Checklist PASS evidence for every proposed builder and blocks appointment/build until complete. |
+| `modules/ALP/BUILD_PROGRESS_TRACKER.md` | Stage 9 named-builder PASS evidence remains an active blocker. |
+
+---
+
+## 3. WS-02 Evidence Decision
+
+```text
+WS-02 Stage 9 Builder Checklist PASS Evidence: BLOCKED.
+Reason: No named builder candidates and no candidate acknowledgements or Foreman role-fit decisions have been recorded.
+Builder Appointment: BLOCKED.
+Build Authorization: BLOCKED.
+Implementation: BLOCKED.
+```
+
+This is a formal blocking-evidence record, not a PASS record.
+
+---
+
+## 4. Required PASS Evidence Per Candidate
+
+Every proposed builder candidate must have all of the following before WS-02 can clear:
+
+| Evidence ID | Required Evidence | Required Location / Link |
+|---|---|---|
+| WS02-EV-001 | Named builder or agent identity | Updated candidate register in `builder-checklist.md` |
+| WS02-EV-002 | Current builder/agent contract link or path | Candidate row and/or linked evidence file |
+| WS02-EV-003 | Assigned wave scope | Candidate row and scope statement |
+| WS02-EV-004 | Stage 6 QA-to-Red acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-005 | Stage 7 PBFAG acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-006 | Stage 8 Implementation Plan acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-007 | WS-07 Runtime / Deployment Contract acknowledgement, if assigned runtime/deployment work | Candidate acknowledgement evidence |
+| WS02-EV-008 | WS-08 Golden Path Verification Pack acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-009 | WS-10 Evidence Folder Convention acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-010 | RED QA suite understanding acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-011 | STOP-AND-FIX and merge-gate compliance acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-012 | Evidence filing responsibility acknowledgement | Candidate acknowledgement evidence |
+| WS02-EV-013 | No unresolved dependency blocker for assigned wave(s) | Candidate dependency statement |
+| WS02-EV-014 | Foreman role-fit decision | Foreman/Governance decision record |
+| WS02-EV-015 | Checklist result set to PASS | Updated Stage 9 checklist |
+
+---
+
+## 5. Candidate Evidence Matrix
+
+| Candidate ID | Proposed Waves | Current Builder / Agent | Contract Current? | Required Acknowledgements Complete? | Foreman Role-Fit Decision | Checklist Result | WS-02 Status |
+|---|---|---|---|---|---|---|---|
+| BC-ALP-001 | W0 | To be assigned | Pending | No | Pending | Pending | BLOCKED |
+| BC-ALP-002 | W1 | To be assigned | Pending | No | Pending | Pending | BLOCKED |
+| BC-ALP-003 | W2 | To be assigned | Pending | No | Pending | Pending | BLOCKED |
+| BC-ALP-004 | W3 | To be assigned | Pending | No | Pending | Pending | BLOCKED |
+| BC-ALP-005 | W4 | To be assigned | Pending | No | Pending | Pending | BLOCKED |
+| BC-ALP-006 | W5 | To be assigned | Pending | No | Pending | Pending | BLOCKED |
+| BC-ALP-007 | W6 | To be assigned | Pending | No | Pending | Pending | BLOCKED |
+| BC-ALP-008 | W7 | To be assigned | Pending | No | Pending | Pending | BLOCKED |
+| BC-ALP-009 | W8 | To be assigned | Pending | No | Pending | Pending | BLOCKED |
+| BC-ALP-010 | W9 | To be assigned | Pending | No | Pending | Pending | BLOCKED |
+
+---
+
+## 6. Acceptable Builder Assignment Models
+
+Foreman/Governance may clear WS-02 using one of these models:
+
+| Model | Description | WS-02 Requirement |
+|---|---|---|
+| Per-wave builders | One named builder per W0-W9 row | Each builder must separately pass the checklist. |
+| Consolidated builder | One named builder covers multiple or all waves | The single builder must acknowledge every assigned wave and pass role-fit review for the full scope. |
+| Hybrid model | Some individual wave builders plus one or more multi-wave builders | Each assigned builder must pass for their declared scope. |
+
+No model is selected by this artifact.
+
+---
+
+## 7. Required Update to Clear WS-02
+
+To clear WS-02, a later PR must update:
+
+```text
+modules/ALP/08-builder-checklist/builder-checklist.md
+modules/ALP/08-builder-checklist/stage9-builder-pass-evidence.md
+modules/ALP/BUILD_PROGRESS_TRACKER.md
+```
+
+The later PR must:
+
+1. name the builder(s);
+2. link current contract(s);
+3. record acknowledgements;
+4. record Foreman role-fit decision(s);
+5. set each applicable candidate row to PASS;
+6. update the tracker blocker state.
+
+---
+
+## 8. Gate Checklist
+
+| Gate Item | Result | Reason |
+|---|---|---|
+| Stage 9 checklist exists | PASS | `builder-checklist.md` exists. |
+| Builder candidates named | BLOCKED | Current candidates are `To be assigned`. |
+| Contracts current | BLOCKED | Current rows are `Pending`. |
+| Candidate acknowledgements complete | BLOCKED | No acknowledgements recorded. |
+| Foreman role-fit decisions recorded | BLOCKED | No decisions recorded. |
+| Checklist PASS evidence for every proposed builder | BLOCKED | No candidate has PASS evidence. |
+| Build authorization preserved as blocked | PASS | No build authorization is granted. |
+
+---
+
+## 9. WS-02 Decision
+
+```text
+WS-02 Stage 9 Builder Checklist PASS Evidence: FILED AS BLOCKING EVIDENCE REGISTER.
+WS-02 completion status: BLOCKED until named builders and PASS evidence are supplied.
+Next required action: identify proposed builder model and named builder(s).
+Builder Appointment: BLOCKED.
+Build Authorization: BLOCKED.
+Implementation: BLOCKED.
+```
+
+---
+
+## 10. Drafting Note (AI-assisted)
+
+This WS-02 evidence register was drafted with AI assistance at user request and is filed for governance review. It does not constitute final Foreman, Product Owner, Technical, Architecture, QA, or Governance approval.
+
+---
+
+## 11. Change History
+
+| Version | Date | Change Description | Changed By | Approval |
+|---|---|---|---|---|
+| 0.1 | 2026-06-17 | Filed WS-02 Stage 9 Builder Checklist PASS Evidence Register as a blocking-evidence record because no named builder PASS evidence exists. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; builder/build remain blocked |

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -16,7 +16,7 @@
 
 ALP is in pre-build remediation. Stages 1 through 6 have been filed at canonical module paths, the Requirement Registry is filed, WS-06 QA range status is confirmed module-local, WS-07 Runtime / Deployment Contract is filed, PR #63 merged the WS-08 Golden Path Verification Pack plus the initialized WS-09 Build Progress Tracker, and PR #64 merged the WS-10 Evidence Folder Convention.
 
-WS-02 Stage 9 Builder Checklist PASS Evidence is being filed in the current PR as a blocking-evidence register because the Stage 9 checklist still has no named builder candidates, no current contracts, no acknowledgements, and no Foreman role-fit decisions.
+WS-02 Stage 9 Builder Checklist PASS Evidence was filed on 2026-06-17 as a blocking-evidence register because the Stage 9 checklist still has no named builder candidates, no current contracts, no acknowledgements, and no Foreman role-fit decisions.
 
 No builder has been appointed. No build has been authorized. No implementation has been authorized.
 

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -3,20 +3,20 @@
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
 **Last Updated**: 2026-06-17  
-**Updated By**: WS-10 Evidence Folder Convention filing after PR #63 merge  
-> **Classification**: ACTIVE - PRE-BUILD REMEDIATION IN PROGRESS - WS-10 FILED FOR REVIEW - BUILD BLOCKED  
+**Updated By**: WS-02 Stage 9 Builder Checklist PASS Evidence blocking register filing after PR #64 merge  
+> **Classification**: ACTIVE - PRE-BUILD REMEDIATION IN PROGRESS - WS-02 FILED AS BLOCKING EVIDENCE - BUILD BLOCKED  
 > **Repository**: APGI-cmy/Training  
 > **Tracker Location**: `modules/ALP/BUILD_PROGRESS_TRACKER.md`  
-> **Current Workstream**: WS-10 - Evidence Folder Convention  
-> **Next Workstream**: WS-02 - Stage 9 Builder Checklist PASS Evidence
+> **Current Workstream**: WS-02 - Stage 9 Builder Checklist PASS Evidence  
+> **Next Required Action**: Identify proposed builder model and named builder(s)
 
 ---
 
 ## Current Executive Status
 
-ALP is in pre-build remediation. Stages 1 through 6 have been filed at canonical module paths, the Requirement Registry is filed, WS-06 QA range status is confirmed module-local, WS-07 Runtime / Deployment Contract is filed, and PR #63 merged the WS-08 Golden Path Verification Pack plus the initialized WS-09 Build Progress Tracker.
+ALP is in pre-build remediation. Stages 1 through 6 have been filed at canonical module paths, the Requirement Registry is filed, WS-06 QA range status is confirmed module-local, WS-07 Runtime / Deployment Contract is filed, PR #63 merged the WS-08 Golden Path Verification Pack plus the initialized WS-09 Build Progress Tracker, and PR #64 merged the WS-10 Evidence Folder Convention.
 
-WS-10 Evidence Folder Convention is being filed for review in the current PR.
+WS-02 Stage 9 Builder Checklist PASS Evidence is being filed in the current PR as a blocking-evidence register because the Stage 9 checklist still has no named builder candidates, no current contracts, no acknowledgements, and no Foreman role-fit decisions.
 
 No builder has been appointed. No build has been authorized. No implementation has been authorized.
 
@@ -24,8 +24,8 @@ No builder has been appointed. No build has been authorized. No implementation h
 Builder Appointment: BLOCKED
 Build Authorization: BLOCKED
 Implementation: BLOCKED
-Current stage/workstream: WS-10 Evidence Folder Convention filed for review
-Next stage/workstream after WS-10 merge: WS-02 - Stage 9 Builder Checklist PASS Evidence
+Current stage/workstream: WS-02 Stage 9 Builder Checklist PASS Evidence filed as blocking evidence
+Next required action: identify builder model and named builder(s)
 ```
 
 ---
@@ -45,7 +45,8 @@ Next stage/workstream after WS-10 merge: WS-02 - Stage 9 Builder Checklist PASS 
 | WS-07 Runtime / Deployment Contract | FILED FOR REVIEW | `modules/ALP/11-build/runtime-deployment-contract.md` |
 | WS-08 Golden Path Verification Pack | MERGED / ACCEPTED ON MAIN | `modules/ALP/11-build/golden-path-verification-pack.md` |
 | WS-09 Build Tracker | INITIALIZED / ACCEPTED ON MAIN | `modules/ALP/BUILD_PROGRESS_TRACKER.md` |
-| WS-10 Evidence Folder Convention | FILED FOR REVIEW IN CURRENT PR | `modules/ALP/11-build/evidence/README.md` |
+| WS-10 Evidence Folder Convention | MERGED / ACCEPTED ON MAIN | `modules/ALP/11-build/evidence/README.md` |
+| WS-02 Stage 9 Builder Checklist PASS Evidence | FILED AS BLOCKING EVIDENCE IN CURRENT PR | `modules/ALP/08-builder-checklist/stage9-builder-pass-evidence.md` |
 | Stage 9 Builder Checklist | FILED BUT NOT PASS-FINALIZED FOR NAMED BUILDERS | `modules/ALP/08-builder-checklist/builder-checklist.md` |
 | Stage 10 IAA Pre-Brief | FILED BUT ACKNOWLEDGEMENTS/ADVISORY STILL BLOCKING | `modules/ALP/09-iaa-pre-brief/iaa-pre-brief.md` |
 | Stage 11 Builder Appointment | BLOCKED | `modules/ALP/10-builder-appointment/builder-appointment.md` |
@@ -175,26 +176,25 @@ QA-ALP-001 through QA-ALP-700
 
 #### W0-W9 Build Wave Status Table
 
-This table records wave status rows, evidence link columns, merge/check status columns, and blocker/risk columns. Wave IDs and scope align to the existing Stage 8 implementation plan and Stage 9 builder checklist. All waves remain blocked until WS-10 is accepted on main, Stage 9/10/11 prerequisites are complete, and final build authorization clears.
+This table records wave status rows, evidence link columns, merge/check status columns, and blocker/risk columns. Wave IDs and scope align to the existing Stage 8 implementation plan and Stage 9 builder checklist. All waves remain blocked until Stage 9/10/11 prerequisites are complete and final build authorization clears.
 
 | Wave | Planned Scope | Status | Evidence Link(s) | Merge / PR Status | Check Status | Blocker / Risk |
 |---|---|---|---|---|---|---|
-| W0 | Foundation / Scaffold: tooling, env, repo structure, base app shell, Supabase config skeleton | BLOCKED - not authorized | Pending | No PR | No checks run | Build authorization blocked; WS-10 pending merge; no appointed builder |
+| W0 | Foundation / Scaffold: tooling, env, repo structure, base app shell, Supabase config skeleton | BLOCKED - not authorized | Pending | No PR | No checks run | Build authorization blocked; no appointed builder |
 | W1 | Auth + Profile + Files: auth, roles, protected layouts, profile, private profile file upload | BLOCKED - not authorized | Pending | No PR | No checks run | Builder appointment blocked; RED-to-GREEN not authorized |
 | W2 | Dashboard + Course Shell + Unit Viewer: learner dashboard, course cards, shell, sidebar, read-only URL-module unit viewer | BLOCKED - not authorized | Pending | No PR | No checks run | Build blocked; CWT evidence not yet executable |
 | W3 | Progress + Completion: progress events, learner progress, module/course completion, next action | BLOCKED - not authorized | Pending | No PR | No checks run | Progress evidence not executable before build authorization |
 | W4 | Enrolment + Payments: invitation, manual enrolment, checkout/webhook/idempotency | BLOCKED - not authorized | Pending | No PR | No checks run | Payment sandbox/secrets not authorized; build blocked |
-| W5 | Assessment Submission: assessment definitions, rubrics, attempts, written/evidence submission | BLOCKED - not authorized | Pending | No PR | No checks run | Storage/evidence convention pending merge; build blocked |
+| W5 | Assessment Submission: assessment definitions, rubrics, attempts, written/evidence submission | BLOCKED - not authorized | Pending | No PR | No checks run | Storage/evidence convention defined but no authorized build |
 | W6 | AI Evaluation + Human Review: AIMC Gateway adapter, AI states, reviewer queue, final outcomes | BLOCKED - not authorized | Pending | No PR | No checks run | AIMC runtime secrets not authorized; build blocked |
 | W7 | Certificates: eligibility, generation, storage, download, certificate events | BLOCKED - not authorized | Pending | No PR | No checks run | Certificate runtime/signing secret not authorized; build blocked |
 | W8 | Admin Reports + Audit: admin operations, reports, audit UI, report filters | BLOCKED - not authorized | Pending | No PR | No checks run | Admin/report evidence not executable before build authorization |
-| W9 | Deployment + CWT: deployed integrated LMS, CWT evidence package, final proof | BLOCKED - not authorized | Pending | No PR | No checks run | WS-10 and final build authorization required; production promotion blocked |
+| W9 | Deployment + CWT: deployed integrated LMS, CWT evidence package, final proof | BLOCKED - not authorized | Pending | No PR | No checks run | Final build authorization required; production promotion blocked |
 
 #### Wave Closure Rule
 
 No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR REVIEW`, or `CLOSED` until all of the following are true:
 
-- WS-10 Evidence Folder Convention is accepted on main;
 - Stage 9 named-builder checklist PASS evidence is complete;
 - Stage 10 acknowledgements/advisory evidence is complete;
 - Stage 11 builder appointment is complete;
@@ -205,7 +205,7 @@ No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR RE
 ---
 
 ### WS-10: Evidence Folder Convention
-**Status**: [x] FILED FOR REVIEW IN CURRENT PR  
+**Status**: [x] MERGED / ACCEPTED ON MAIN  
 **Expected Location**: `modules/ALP/11-build/evidence/`  
 **Key Artifacts**:
 - [x] `modules/ALP/11-build/evidence/README.md`
@@ -223,12 +223,30 @@ No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR RE
 
 ---
 
+### WS-02: Stage 9 Builder Checklist PASS Evidence
+**Status**: [ ] FILED AS BLOCKING EVIDENCE IN CURRENT PR  
+**Location**: `modules/ALP/08-builder-checklist/`  
+**Key Artifacts**:
+- [x] `stage9-builder-pass-evidence.md`
+- [x] `builder-checklist.md`
+- [x] `builder-checklist-review-resolution.md`
+
+**Remaining Need**:
+- [ ] Named builder identity or builder model selected
+- [ ] Current builder contract(s) linked
+- [ ] Builder acknowledgements recorded
+- [ ] Foreman role-fit decision(s) recorded
+- [ ] Explicit PASS state for selected builder(s)
+
+---
+
 ### Stage 9: Builder Checklist
 **Status**: [ ] BLOCKED / NOT FINALIZED FOR NAMED BUILDERS  
 **Location**: `modules/ALP/08-builder-checklist/`  
 **Key Artifacts**:
 - [x] `builder-checklist.md`
 - [x] `builder-checklist-review-resolution.md`
+- [x] `stage9-builder-pass-evidence.md` - current PR
 
 **Remaining Need**:
 - [ ] Named builder readiness evidence
@@ -269,12 +287,13 @@ No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR RE
 - [x] `carry-forward-artifact-verification.md`
 - [x] `runtime-deployment-contract.md`
 - [x] `golden-path-verification-pack.md`
-- [x] `evidence/README.md` - current PR
+- [x] `evidence/README.md`
 
 **Stage 12 cannot begin until**:
 - [x] WS-08 is merged and reviewed
 - [x] WS-09 tracker is current and accepted
-- [ ] WS-10 evidence convention is merged and accepted
+- [x] WS-10 evidence convention is merged and accepted
+- [ ] WS-02 Stage 9 builder PASS evidence is complete
 - [ ] Stage 9 builder checklist is pass-finalized for named builder(s)
 - [ ] Stage 10 acknowledgements/advisory are complete
 - [ ] Stage 11 builder appointment is complete
@@ -286,24 +305,17 @@ No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR RE
 
 | Blocker ID | Blocker | Current Status | Required Next Action |
 |---|---|---|---|
-| ALP-BLOCK-001 | WS-10 evidence folder convention not merged | In current PR | Review and merge WS-10 artifact |
-| ALP-BLOCK-002 | Stage 9 named-builder PASS evidence incomplete | Open | Complete builder checklist finalization |
-| ALP-BLOCK-003 | Stage 10 acknowledgements/advisory incomplete | Open | Complete IAA/advisory evidence |
-| ALP-BLOCK-004 | Stage 11 actual builder appointment incomplete | Open | Appoint builder only after prerequisites clear |
-| ALP-BLOCK-005 | Stage 12 final build authorization missing | Open | Issue only after all blockers clear |
+| ALP-BLOCK-001 | WS-02 Stage 9 named-builder PASS evidence incomplete | Blocking evidence register in current PR | Identify builder model and named builder(s) |
+| ALP-BLOCK-002 | Stage 10 acknowledgements/advisory incomplete | Open | Complete IAA/advisory evidence after builder model is known |
+| ALP-BLOCK-003 | Stage 11 actual builder appointment incomplete | Open | Appoint builder only after prerequisites clear |
+| ALP-BLOCK-004 | Stage 12 final build authorization missing | Open | Issue only after all blockers clear |
 
 ---
 
 ## Immediate Next Action
 
 ```text
-Review and merge the WS-10 Evidence Folder Convention and ALP Build Progress Tracker update PR.
-```
-
-After this PR merges, the next workstream is:
-
-```text
-WS-02 - Stage 9 Builder Checklist PASS Evidence
+Review and merge the WS-02 blocking-evidence register PR, then identify the proposed builder model and named builder(s).
 ```
 
 The tracker itself must continue to be kept current as each remaining blocker changes.
@@ -333,3 +345,4 @@ No percentage-complete claim is made because ALP has not entered authorized buil
 | 0.2 | 2026-06-17 | Added required W0-W9 wave status table with evidence, merge/check status, and blocker/risk columns. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |
 | 0.3 | 2026-06-17 | Updated tracker after PR #63 merge and filed WS-10 Evidence Folder Convention for review. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |
 | 0.4 | 2026-06-17 | Aligned W0-W9 tracker rows to the existing Stage 8 implementation plan and Stage 9 builder checklist wave definitions. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |
+| 0.5 | 2026-06-17 | Updated tracker after PR #64 merge and filed WS-02 Stage 9 Builder Checklist PASS Evidence as a blocking-evidence register. | AI-assisted draft (pending Foreman/Governance review) | Filed for review; build remains blocked |

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -46,7 +46,7 @@ Next required action: identify builder model and named builder(s)
 | WS-08 Golden Path Verification Pack | MERGED / ACCEPTED ON MAIN | `modules/ALP/11-build/golden-path-verification-pack.md` |
 | WS-09 Build Tracker | INITIALIZED / ACCEPTED ON MAIN | `modules/ALP/BUILD_PROGRESS_TRACKER.md` |
 | WS-10 Evidence Folder Convention | MERGED / ACCEPTED ON MAIN | `modules/ALP/11-build/evidence/README.md` |
-| WS-02 Stage 9 Builder Checklist PASS Evidence | FILED AS BLOCKING EVIDENCE IN CURRENT PR | `modules/ALP/08-builder-checklist/stage9-builder-pass-evidence.md` |
+| WS-02 Stage 9 Builder Checklist PASS Evidence | FILED AS BLOCKING EVIDENCE (2026-06-17) | `modules/ALP/08-builder-checklist/stage9-builder-pass-evidence.md` |
 | Stage 9 Builder Checklist | FILED BUT NOT PASS-FINALIZED FOR NAMED BUILDERS | `modules/ALP/08-builder-checklist/builder-checklist.md` |
 | Stage 10 IAA Pre-Brief | FILED BUT ACKNOWLEDGEMENTS/ADVISORY STILL BLOCKING | `modules/ALP/09-iaa-pre-brief/iaa-pre-brief.md` |
 | Stage 11 Builder Appointment | BLOCKED | `modules/ALP/10-builder-appointment/builder-appointment.md` |

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -246,7 +246,7 @@ No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR RE
 **Key Artifacts**:
 - [x] `builder-checklist.md`
 - [x] `builder-checklist-review-resolution.md`
-- [x] `stage9-builder-pass-evidence.md` - current PR
+- [x] `stage9-builder-pass-evidence.md` (filed 2026-06-17)
 
 **Remaining Need**:
 - [ ] Named builder readiness evidence

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -224,7 +224,7 @@ No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR RE
 ---
 
 ### WS-02: Stage 9 Builder Checklist PASS Evidence
-**Status**: [ ] FILED AS BLOCKING EVIDENCE IN CURRENT PR  
+**Status**: [ ] BLOCKED (blocking-evidence register filed 2026-06-17)  
 **Location**: `modules/ALP/08-builder-checklist/`  
 **Key Artifacts**:
 - [x] `stage9-builder-pass-evidence.md`

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -305,7 +305,7 @@ No wave may move from `BLOCKED - not authorized` to `IN PROGRESS`, `READY FOR RE
 
 | Blocker ID | Blocker | Current Status | Required Next Action |
 |---|---|---|---|
-| ALP-BLOCK-001 | WS-02 Stage 9 named-builder PASS evidence incomplete | Blocking evidence register in current PR | Identify builder model and named builder(s) |
+| ALP-BLOCK-001 | WS-02 Stage 9 named-builder PASS evidence incomplete | Blocking evidence register filed 2026-06-17 | Identify builder model and named builder(s) |
 | ALP-BLOCK-002 | Stage 10 acknowledgements/advisory incomplete | Open | Complete IAA/advisory evidence after builder model is known |
 | ALP-BLOCK-003 | Stage 11 actual builder appointment incomplete | Open | Appoint builder only after prerequisites clear |
 | ALP-BLOCK-004 | Stage 12 final build authorization missing | Open | Issue only after all blockers clear |


### PR DESCRIPTION
## Summary

Files the WS-02 Stage 9 Builder Checklist PASS Evidence register and updates the ALP progress tracker.

## Adds

- `modules/ALP/08-builder-checklist/stage9-builder-pass-evidence.md`

## Updates

- `modules/ALP/BUILD_PROGRESS_TRACKER.md`

## Important governance finding

This PR does **not** claim Stage 9 builder PASS.

It records that WS-02 remains blocked because the current Stage 9 checklist still has:

- no named builder candidates
- no current builder contracts
- no candidate acknowledgements
- no Foreman role-fit decisions
- no candidate-specific PASS results

## Required next action

After this PR merges, the next required action is to identify the proposed builder model and named builder(s):

- per-wave builders
- consolidated builder
- hybrid model

## Governance status

This PR does **not** authorize builder appointment, build, implementation, CODE_PASS, FUNCTIONAL_PASS, or CWT_PASS.