### PR TITLE
Implement ALP W1 schema security pass

### DIFF
--- a/modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md
+++ b/modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md
@@ -1,0 +1,96 @@
+# W1 Schema / Security Pass Evidence
+
+## Status Header
+
+| Field | Value |
+|---|---|
+| Module | ALP - APGI Learning Portal |
+| Wave | W1 - Auth + Profile + Files |
+| Evidence Type | Schema/security pass evidence |
+| Status | Filed for review |
+| Date | 2026-06-25 |
+| Builder | BC-ALP-CONSOLIDATED-001 |
+| Repository | APGI-cmy/Training |
+| Branch | alp-w1-schema-security |
+| Planned PR | #73 |
+
+---
+
+## 1. Purpose
+
+This artifact records the first W1 implementation slice: schema/security only.
+
+This pass replaces W0 placeholder database artifacts with real W1 tables, profile/private-file metadata structures, storage bucket expectations, audit hooks, and RLS policies.
+
+This pass does not implement UI login, logout/session handling, profile forms, upload actions, browser proof, deployment acceptance, or CWT closure.
+
+---
+
+## 2. Implemented Artifacts
+
+| Area | Path | Status |
+|---|---|---|
+| Auth/profile schema | `supabase/migrations/001_alp_auth_profile.sql` | W0 placeholder replaced with W1 schema |
+| File/audit/storage schema | `supabase/migrations/006_alp_files_certificates_notifications_audit.sql` | Created W1 profile/file/audit subset |
+| RLS policies | `supabase/migrations/007_alp_rls_policies.sql` | W0 placeholder replaced with W1 RLS policies |
+| Progress tracker | `modules/ALP/BUILD_PROGRESS_TRACKER.md` | Updated for W1 schema/security pass |
+| Evidence index | `modules/ALP/11-build/evidence/index.md` | Updated with this evidence row |
+
+---
+
+## 3. Schema Coverage
+
+| W1 Requirement | Evidence |
+|---|---|
+| `learners` base table | `public.learners` created with status/timestamps and `auth.users` ownership |
+| `user_roles` base table | `public.user_roles` created with learner/admin/reviewer/course_publisher role check |
+| `profiles` base table | `public.profiles` created with certificate-critical fields and profile lock guard |
+| `file_metadata` base table | `public.file_metadata` created for private profile/file ownership and object paths |
+| Private file bucket expectation | `storage.buckets` upsert for `alp-private-files` with `public = false` |
+| Audit hooks | `public.audit_events`, profile audit trigger, and file metadata audit trigger |
+
+---
+
+## 4. RLS / Privacy Coverage
+
+| Control | Evidence |
+|---|---|
+| RLS enabled | `learners`, `user_roles`, `profiles`, `file_metadata`, and `audit_events` enable RLS |
+| Role helper | `current_user_has_role()` and `current_user_has_any_role()` added |
+| Learner isolation | Learner/profile/file policies use `auth.uid()` ownership checks |
+| Staff access boundary | admin/reviewer read access is explicit where needed |
+| Private storage isolation | `storage.objects` policies restrict `alp-private-files` object access by owner path or staff role |
+| Cross-learner denial basis | profile/file select/update policies deny unrelated authenticated users by default |
+
+---
+
+## 5. Verification Status
+
+| Check | Status | Notes |
+|---|---|---|
+| Local migration execution | Not run by connector | No local Supabase execution claim made. |
+| Local tests | Not run by connector | No CODE_PASS or FUNCTIONAL_PASS claim made. |
+| Vercel/GitHub checks | Pending PR checks | To be reviewed on PR #73 after creation. |
+| Browser login proof | Not included | Reserved for W1 app/auth pass. |
+| Profile save proof | Not included | Reserved for W1 app/auth pass. |
+| File upload/private access proof | Not included | Reserved for W1 app/auth pass. |
+
+---
+
+## 6. Explicit Non-Claims
+
+```text
+FULL APP DELIVERY: NOT CLAIMED.
+CODE_PASS: NOT CLAIMED.
+FUNCTIONAL_PASS: NOT CLAIMED.
+CWT_PASS: NOT CLAIMED.
+Deployment acceptance: NOT CLAIMED.
+Production readiness: NOT CLAIMED.
+W1 closure: NOT CLAIMED.
+```
+
+---
+
+## 7. Required Next Action
+
+Review PR #73 for the W1 schema/security pass. If accepted, continue W1 with the app/auth pass: login/logout/session handling, protected layouts, profile form, and upload actions.

--- a/modules/ALP/11-build/evidence/index.md
+++ b/modules/ALP/11-build/evidence/index.md
@@ -7,7 +7,7 @@
 | Module | ALP - APGI Learning Portal |
 | Artifact | Build Evidence Index |
 | Status | Filed for review |
-| Date | 2026-06-24 |
+| Date | 2026-06-25 |
 | Repository | APGI-cmy/Training |
 | Canonical Path | `modules/ALP/11-build/evidence/index.md` |
 
@@ -18,7 +18,8 @@
 | Wave | Evidence File | QA Marker(s) | Golden / Negative Path | Environment | PR / Commit | Check Status | Reviewer / Owner | Closure Status | Notes |
 |---|---|---|---|---|---|---|---|---|---|
 | W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | governance-artifacts; architecture-inventory; deployment-cwt subset | Golden scaffold/governance path | GitHub / Vercel preview | PR #71 / `48ce32a1974b14487864713af1287ab0379cf4d8` | Vercel accepted before PR #71 merge | BC-ALP-CONSOLIDATED-001 / governance review | Closed for scaffold scope; filed for W1 entry review | Does not claim full app delivery, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness. |
-| W0 | `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | GOV-ALP-072 | Golden governance closure path | GitHub PR evidence | PR #72 / pending merge | Vercel pending or to be reviewed on PR #72 | BC-ALP-CONSOLIDATED-001 / governance review | Filed for review | Authorizes W1 Auth + Profile + Files entry only; no W1 implementation delivered. |
+| W0 | `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | GOV-ALP-072 | Golden governance closure path | GitHub PR evidence | PR #72 / `60663768ca2a960fbfd4d9a50bf88c71a4479e25` | Vercel accepted before PR #72 merge | BC-ALP-CONSOLIDATED-001 / governance review | Filed for review / W1 entry authorized | Authorizes W1 Auth + Profile + Files entry only; no W1 implementation delivered. |
+| W1 | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | auth; security-privacy; architecture-inventory | Golden schema/security path plus negative RLS design basis | GitHub PR evidence | PR #73 / pending merge | Pending PR checks | BC-ALP-CONSOLIDATED-001 / governance review | Filed for review | Schema/security slice only. Does not claim W1 closure, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness. |
 
 ---
 
@@ -31,4 +32,5 @@ FUNCTIONAL_PASS: NOT CLAIMED.
 CWT_PASS: NOT CLAIMED.
 Deployment acceptance: NOT CLAIMED.
 Production readiness: NOT CLAIMED.
+W1 closure: NOT CLAIMED.
 ```

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -2,21 +2,21 @@
 
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
-**Last Updated**: 2026-06-24  
-**Updated By**: W0 Closure / W1 Entry Authorization filing  
-> **Classification**: ACTIVE - W0 FOUNDATION / SCAFFOLD CLOSED - W1 AUTH + PROFILE + FILES AUTHORIZED FOR ENTRY  
+**Last Updated**: 2026-06-25  
+**Updated By**: W1 Schema / Security pass filing  
+> **Classification**: ACTIVE - W1 AUTH + PROFILE + FILES SCHEMA / SECURITY PASS FILED FOR REVIEW  
 > **Repository**: APGI-cmy/Training  
 > **Tracker Location**: `modules/ALP/BUILD_PROGRESS_TRACKER.md`  
 > **Current Workstream**: W1 Auth + Profile + Files  
-> **Next Required Action**: Open W1 implementation PR with required schema, auth/profile/file implementation, tests, and evidence
+> **Next Required Action**: Review W1 schema/security PR checks and evidence
 
 ---
 
 ## Current Executive Status
 
-ALP is in authorized build execution after Stage 12 Build Authorization. W0 Foundation / Scaffold was merged through PR #71 and is now closed as the scaffold-entry wave for W1.
+ALP is in authorized build execution after Stage 12 Build Authorization. W0 Foundation / Scaffold was merged through PR #71 and W1 entry was authorized through PR #72.
 
-This tracker update records W0 closure and W1 entry authorization only. It does not claim full app delivery, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness.
+This tracker update records the W1 schema/security implementation slice for review. It does not claim W1 closure, full app delivery, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness.
 
 ```text
 Builder Model: CONSOLIDATED BUILDER MODEL SELECTED
@@ -25,8 +25,9 @@ Builder Appointment: APPOINTED FOR STAGE 12 BUILD AUTHORIZATION REVIEW
 Build Authorization: AUTHORIZED BY PR #70
 Implementation Authorization: AUTHORIZED FOR W0-W9 UNDER STAGE 12 CONTROLS
 Completed workstream: W0 Foundation / Scaffold closed by PR #71
-Current workstream: W1 Auth + Profile + Files authorized for entry
-Next required action: open W1 implementation PR with evidence
+Current workstream: W1 Auth + Profile + Files
+Current slice: W1 schema/security pass filed for review
+Next required action: review W1 schema/security PR checks and evidence
 FULL APP DELIVERY / CODE_PASS / FUNCTIONAL_PASS / CWT_PASS: NOT CLAIMED
 ```
 
@@ -46,15 +47,15 @@ FULL APP DELIVERY / CODE_PASS / FUNCTIONAL_PASS / CWT_PASS: NOT CLAIMED
 | WS-06 QA-ALP Range Status | CONFIRMED MODULE-LOCAL | `modules/ALP/05-qa-to-red/qa-alp-range-status.md` |
 | WS-07 Runtime / Deployment Contract | FILED FOR REVIEW | `modules/ALP/11-build/runtime-deployment-contract.md` |
 | WS-08 Golden Path Verification Pack | MERGED / ACCEPTED ON MAIN | `modules/ALP/11-build/golden-path-verification-pack.md` |
-| WS-09 Build Tracker | UPDATED FOR W0 CLOSURE / W1 ENTRY | `modules/ALP/BUILD_PROGRESS_TRACKER.md` |
+| WS-09 Build Tracker | UPDATED FOR W1 SCHEMA / SECURITY PASS | `modules/ALP/BUILD_PROGRESS_TRACKER.md` |
 | WS-10 Evidence Folder Convention | MERGED / ACCEPTED ON MAIN | `modules/ALP/11-build/evidence/README.md` |
 | Stage 9 Builder Evidence | COMPANION EVIDENCE ACCEPTED / SUPERSEDED FOR AUTHORIZATION REVIEW | `modules/ALP/08-builder-checklist/consolidated-builder-stage9-evidence.md` |
 | Stage 10 IAA Acknowledgement Evidence | COMPANION EVIDENCE ACCEPTED / SUPERSEDED FOR AUTHORIZATION REVIEW | `modules/ALP/09-iaa-pre-brief/stage10-iaa-acknowledgement-evidence.md` |
 | Stage 11 Builder Appointment | MERGED / ACCEPTED FOR STAGE 12 BUILD AUTHORIZATION REVIEW | `modules/ALP/10-builder-appointment/builder-appointment.md` |
 | Stage 12 Build Authorization | MERGED / BUILD AUTHORIZED | `modules/ALP/11-build/build-authorization.md` |
 | W0 Foundation / Scaffold | CLOSED / FILED FOR REVIEW | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md`; `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` |
-| W1 Auth + Profile + Files | AUTHORIZED FOR ENTRY | Requires W1 implementation PR and evidence |
-| Full App Delivery | NOT DELIVERED BY W0 | Requires W1-W9 implementation and evidence |
+| W1 Auth + Profile + Files | SCHEMA / SECURITY PASS FILED FOR REVIEW | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` |
+| Full App Delivery | NOT DELIVERED BY W1 SCHEMA PASS | Requires W1-W9 implementation and evidence |
 
 ---
 
@@ -62,8 +63,8 @@ FULL APP DELIVERY / CODE_PASS / FUNCTIONAL_PASS / CWT_PASS: NOT CLAIMED
 
 | Wave | Planned Scope | Status | Evidence Link(s) | Merge / PR Status | Check Status | Blocker / Risk |
 |---|---|---|---|---|---|---|
-| W0 | Foundation / Scaffold: tooling, env, repo structure, base app shell, Supabase config skeleton | CLOSED / FILED FOR REVIEW | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md`; `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | PR #71 merged to `main` | Vercel/GitHub checks accepted for PR #71 before merge | Closed for scaffold scope only; no full app delivery claimed |
-| W1 | Auth + Profile + Files: auth, roles, protected layouts, profile, private profile file upload | AUTHORIZED FOR ENTRY | Pending W1 evidence | No W1 build PR yet | No W1 build checks run | Must replace W0 placeholders with real auth/profile/file implementation |
+| W0 | Foundation / Scaffold: tooling, env, repo structure, base app shell, Supabase config skeleton | CLOSED / FILED FOR REVIEW | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md`; `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | PR #71 merged to `main`; PR #72 merged W1 entry | Vercel/GitHub checks accepted before merge | Closed for scaffold scope only; no full app delivery claimed |
+| W1 | Auth + Profile + Files: auth, roles, protected layouts, profile, private profile file upload | SCHEMA / SECURITY PASS FILED FOR REVIEW | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | PR #73 pending | Pending PR checks | App/auth UI/actions still pending; W1 closure not claimed |
 | W2 | Dashboard + Course Shell + Unit Viewer: learner dashboard, course cards, shell, sidebar, read-only URL-module unit viewer | AUTHORIZED AFTER W1 GREEN | Pending W2 evidence | No build PR yet | No build checks run | Requires W1 closure |
 | W3 | Progress + Completion: progress events, learner progress, module/course completion, next action | AUTHORIZED AFTER W2 GREEN | Pending W3 evidence | No build PR yet | No build checks run | Requires W2 closure |
 | W4 | Enrolment + Payments: invitation, manual enrolment, checkout/webhook/idempotency | AUTHORIZED AFTER W1/W2 GREEN | Pending W4 evidence | No build PR yet | No build checks run | Requires W1/W2 closure |
@@ -85,10 +86,10 @@ FULL APP DELIVERY / CODE_PASS / FUNCTIONAL_PASS / CWT_PASS: NOT CLAIMED
 | Stage 10 companion evidence | ACCEPTED / SUPERSEDED FOR AUTHORIZATION REVIEW | PR #68 evidence plus Stage 12 supersession note. |
 | Stage 11 builder appointment | COMPLETE FOR STAGE 12 BUILD AUTHORIZATION REVIEW | PR #69 appointment. |
 | Stage 12 build authorization | COMPLETE | PR #70 merged. |
-| W0 Foundation / Scaffold | CLOSED / FILED FOR REVIEW | PR #71 merged. Closure evidence filed in this PR. |
-| W1 Auth + Profile + Files | AUTHORIZED FOR ENTRY | Next implementation PR must file W1 evidence and withhold pass claims until supported. |
+| W0 Foundation / Scaffold | CLOSED / FILED FOR REVIEW | PR #71 merged; PR #72 filed W1 entry evidence. |
+| W1 Auth + Profile + Files | SCHEMA / SECURITY PASS FILED FOR REVIEW | PR #73 must be reviewed; W1 app/auth flow remains pending. |
 | Implementation | AUTHORIZED FOR W0-W9 | Wave closure remains evidence-gated. |
-| Full app workflows | NOT DELIVERED BY W0 | Requires W1-W9. |
+| Full app workflows | NOT DELIVERED BY W1 SCHEMA PASS | Requires W1-W9. |
 | CODE_PASS | NOT CLAIMED | Requires later code evidence. |
 | FUNCTIONAL_PASS | NOT CLAIMED | Requires later functional evidence. |
 | CWT_PASS | NOT CLAIMED | Requires later deployment/CWT evidence. |
@@ -105,17 +106,18 @@ FULL APP DELIVERY / CODE_PASS / FUNCTIONAL_PASS / CWT_PASS: NOT CLAIMED
 | ALP-CTRL-004 | No CODE_PASS yet | Open | Claim only after code evidence exists. |
 | ALP-CTRL-005 | No FUNCTIONAL_PASS yet | Open | Claim only after functional evidence exists. |
 | ALP-CTRL-006 | No CWT_PASS yet | Open | Claim only after deployment/CWT evidence exists. |
-| ALP-CTRL-007 | W1 implementation not yet filed | Open | Open W1 Auth + Profile + Files implementation PR. |
+| ALP-CTRL-007 | W1 implementation not yet complete | Open | Complete W1 app/auth/profile/file action pass after schema/security review. |
+| ALP-CTRL-008 | W1 schema/security PR checks | Open | Review PR #73 checks and evidence. |
 
 ---
 
 ## Immediate Next Action
 
 ```text
-Open the W1 Auth + Profile + Files implementation PR.
+Review the W1 schema/security implementation PR and checks.
 ```
 
-The W1 PR must implement the authorized W1 scope and file fresh W1 evidence before any W1 closure or pass claim.
+The W1 schema/security pass must be accepted before W1 proceeds to app/auth/profile/file action implementation. W1 closure is not claimed by this schema/security slice.
 
 ---
 
@@ -128,14 +130,15 @@ Builder Appointment: APPOINTED FOR STAGE 12 BUILD AUTHORIZATION REVIEW
 Build Authorization: AUTHORIZED BY PR #70
 Implementation Authorization: AUTHORIZED FOR W0-W9 UNDER STAGE 12 CONTROLS
 W0 Foundation / Scaffold: CLOSED BY PR #71
-W1 Auth + Profile + Files: AUTHORIZED FOR ENTRY
+W1 Auth + Profile + Files: SCHEMA / SECURITY PASS FILED FOR REVIEW
 Full App Delivery: NOT CLAIMED
 Functional Pass: NOT CLAIMED
 Code Pass: NOT CLAIMED
 CWT Pass: NOT CLAIMED
+W1 Closure: NOT CLAIMED
 ```
 
-No percentage-complete claim is made because ALP has not yet accepted full build-wave evidence beyond W0 scaffold closure.
+No percentage-complete claim is made because ALP has not yet accepted full W1 build-wave evidence.
 
 ---
 
@@ -155,3 +158,4 @@ No percentage-complete claim is made because ALP has not yet accepted full build
 | 1.0 | 2026-06-23 | Filed W0 Foundation / Scaffold implementation and evidence for review. | AI-assisted draft | Filed for review; pass claims withheld |
 | 1.1 | 2026-06-24 | Recorded independent-review fixes and explicit full-app/non-functional/CWT non-claims for W0. | AI-assisted draft | Filed for review; full delivery not claimed |
 | 1.2 | 2026-06-24 | Closed W0 Foundation / Scaffold after PR #71 merge and authorized W1 Auth + Profile + Files entry. | AI-assisted draft | Filed for review; W1 implementation not yet filed |
+| 1.3 | 2026-06-25 | Filed W1 schema/security implementation slice: schema tables, private file metadata, audit hooks, storage bucket expectation, and RLS policies. | AI-assisted draft | Filed for review; W1 closure not claimed |

--- a/supabase/migrations/001_alp_auth_profile.sql
+++ b/supabase/migrations/001_alp_auth_profile.sql
@@ -1,6 +1,86 @@
--- APGI Learning Portal W0 migration placeholder
--- Auth/profile schema is implemented in W1 after W0 scaffold closes.
--- This file reserves the expected Supabase migration path only.
--- It does not satisfy schema-content tests for user_roles, profiles, learners, storage, or policies.
+-- APGI Learning Portal W1 auth/profile schema
+-- Scope: W1 Auth + Profile + Files schema/security pass.
+-- This migration replaces the W0 placeholder with real base tables for
+-- learners, user roles, profiles, and profile file metadata.
 
-select 1;
+create extension if not exists pgcrypto;
+
+create table if not exists public.learners (
+  id uuid primary key references auth.users(id) on delete cascade,
+  status text not null default 'active' check (status in ('active', 'suspended', 'archived')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.user_roles (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  role text not null check (role in ('learner', 'admin', 'reviewer', 'course_publisher')),
+  assigned_by uuid references auth.users(id) on delete set null,
+  assigned_at timestamptz not null default now(),
+  unique (user_id, role)
+);
+
+create table if not exists public.profiles (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  email text,
+  full_name text,
+  preferred_name text,
+  certificate_name text,
+  phone text,
+  country text,
+  certificate_profile_locked_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint profiles_certificate_name_required_when_locked
+    check (certificate_profile_locked_at is null or nullif(trim(coalesce(certificate_name, '')), '') is not null)
+);
+
+create table if not exists public.file_metadata (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  profile_user_id uuid references public.profiles(user_id) on delete cascade,
+  bucket_id text not null default 'alp-private-files',
+  object_path text not null,
+  original_filename text not null,
+  mime_type text,
+  size_bytes bigint check (size_bytes is null or size_bytes >= 0),
+  file_purpose text not null check (file_purpose in ('profile_photo', 'cv', 'assessment_evidence', 'certificate', 'other')),
+  visibility text not null default 'private' check (visibility = 'private'),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (bucket_id, object_path),
+  constraint file_metadata_owner_matches_profile
+    check (profile_user_id is null or profile_user_id = owner_user_id)
+);
+
+create index if not exists idx_user_roles_user_id on public.user_roles(user_id);
+create index if not exists idx_user_roles_role on public.user_roles(role);
+create index if not exists idx_file_metadata_owner_user_id on public.file_metadata(owner_user_id);
+create index if not exists idx_file_metadata_profile_user_id on public.file_metadata(profile_user_id);
+create index if not exists idx_file_metadata_bucket_object on public.file_metadata(bucket_id, object_path);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_learners_updated_at on public.learners;
+create trigger set_learners_updated_at
+before update on public.learners
+for each row execute function public.set_updated_at();
+
+drop trigger if exists set_profiles_updated_at on public.profiles;
+create trigger set_profiles_updated_at
+before update on public.profiles
+for each row execute function public.set_updated_at();
+
+drop trigger if exists set_file_metadata_updated_at on public.file_metadata;
+create trigger set_file_metadata_updated_at
+before update on public.file_metadata
+for each row execute function public.set_updated_at();

--- a/supabase/migrations/006_alp_files_certificates_notifications_audit.sql
+++ b/supabase/migrations/006_alp_files_certificates_notifications_audit.sql
@@ -1,0 +1,125 @@
+-- APGI Learning Portal W1 file storage and audit schema subset
+-- Scope: profile/private-file storage expectations and audit hooks required for W1.
+-- Certificate and notification structures remain reserved for later waves.
+
+create table if not exists public.audit_events (
+  id uuid primary key default gen_random_uuid(),
+  actor_user_id uuid references auth.users(id) on delete set null,
+  target_user_id uuid references auth.users(id) on delete set null,
+  event_type text not null,
+  entity_type text not null,
+  entity_id uuid,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_audit_events_actor_user_id on public.audit_events(actor_user_id);
+create index if not exists idx_audit_events_target_user_id on public.audit_events(target_user_id);
+create index if not exists idx_audit_events_event_type on public.audit_events(event_type);
+create index if not exists idx_audit_events_created_at on public.audit_events(created_at desc);
+
+create or replace function public.write_audit_event(
+  p_event_type text,
+  p_entity_type text,
+  p_entity_id uuid default null,
+  p_target_user_id uuid default null,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_event_id uuid;
+begin
+  insert into public.audit_events (
+    actor_user_id,
+    target_user_id,
+    event_type,
+    entity_type,
+    entity_id,
+    metadata
+  ) values (
+    auth.uid(),
+    p_target_user_id,
+    p_event_type,
+    p_entity_type,
+    p_entity_id,
+    coalesce(p_metadata, '{}'::jsonb)
+  )
+  returning id into v_event_id;
+
+  return v_event_id;
+end;
+$$;
+
+create or replace function public.audit_profile_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  perform public.write_audit_event(
+    case when tg_op = 'INSERT' then 'profile.created' else 'profile.updated' end,
+    'profiles',
+    new.user_id,
+    new.user_id,
+    jsonb_build_object('operation', tg_op)
+  );
+  return new;
+end;
+$$;
+
+drop trigger if exists audit_profiles_insert_update on public.profiles;
+create trigger audit_profiles_insert_update
+after insert or update on public.profiles
+for each row execute function public.audit_profile_change();
+
+create or replace function public.audit_file_metadata_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  perform public.write_audit_event(
+    case when tg_op = 'INSERT' then 'file_metadata.created' else 'file_metadata.updated' end,
+    'file_metadata',
+    new.id,
+    new.owner_user_id,
+    jsonb_build_object(
+      'operation', tg_op,
+      'file_purpose', new.file_purpose,
+      'bucket_id', new.bucket_id
+    )
+  );
+  return new;
+end;
+$$;
+
+drop trigger if exists audit_file_metadata_insert_update on public.file_metadata;
+create trigger audit_file_metadata_insert_update
+after insert or update on public.file_metadata
+for each row execute function public.audit_file_metadata_change();
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'alp-private-files',
+  'alp-private-files',
+  false,
+  10485760,
+  array[
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+  ]
+)
+on conflict (id) do update set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;

--- a/supabase/migrations/007_alp_rls_policies.sql
+++ b/supabase/migrations/007_alp_rls_policies.sql
@@ -1,6 +1,224 @@
--- APGI Learning Portal W0 RLS placeholder
--- Concrete RLS policies are implemented in later waves when tables exist.
--- This file reserves the expected Supabase RLS migration path only.
--- It does not satisfy RLS-content tests for profiles, auth.uid(), private file policies, or learner isolation.
+-- APGI Learning Portal W1 RLS policies
+-- Scope: auth/profile/private-file isolation for W1.
 
-select 1;
+alter table public.learners enable row level security;
+alter table public.user_roles enable row level security;
+alter table public.profiles enable row level security;
+alter table public.file_metadata enable row level security;
+alter table public.audit_events enable row level security;
+
+create or replace function public.current_user_has_role(required_role text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.user_roles ur
+    where ur.user_id = auth.uid()
+      and ur.role = required_role
+  );
+$$;
+
+create or replace function public.current_user_has_any_role(required_roles text[])
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.user_roles ur
+    where ur.user_id = auth.uid()
+      and ur.role = any(required_roles)
+  );
+$$;
+
+drop policy if exists learners_select_self_or_admin on public.learners;
+create policy learners_select_self_or_admin
+on public.learners
+for select
+using (
+  id = auth.uid()
+  or public.current_user_has_role('admin')
+);
+
+drop policy if exists learners_insert_self_or_admin on public.learners;
+create policy learners_insert_self_or_admin
+on public.learners
+for insert
+with check (
+  id = auth.uid()
+  or public.current_user_has_role('admin')
+);
+
+drop policy if exists learners_update_self_or_admin on public.learners;
+create policy learners_update_self_or_admin
+on public.learners
+for update
+using (
+  id = auth.uid()
+  or public.current_user_has_role('admin')
+)
+with check (
+  id = auth.uid()
+  or public.current_user_has_role('admin')
+);
+
+drop policy if exists user_roles_select_self_or_admin on public.user_roles;
+create policy user_roles_select_self_or_admin
+on public.user_roles
+for select
+using (
+  user_id = auth.uid()
+  or public.current_user_has_role('admin')
+);
+
+drop policy if exists user_roles_admin_insert on public.user_roles;
+create policy user_roles_admin_insert
+on public.user_roles
+for insert
+with check (public.current_user_has_role('admin'));
+
+drop policy if exists user_roles_admin_update on public.user_roles;
+create policy user_roles_admin_update
+on public.user_roles
+for update
+using (public.current_user_has_role('admin'))
+with check (public.current_user_has_role('admin'));
+
+drop policy if exists user_roles_admin_delete on public.user_roles;
+create policy user_roles_admin_delete
+on public.user_roles
+for delete
+using (public.current_user_has_role('admin'));
+
+drop policy if exists profiles_select_self_or_staff on public.profiles;
+create policy profiles_select_self_or_staff
+on public.profiles
+for select
+using (
+  user_id = auth.uid()
+  or public.current_user_has_any_role(array['admin', 'reviewer'])
+);
+
+drop policy if exists profiles_insert_self_or_admin on public.profiles;
+create policy profiles_insert_self_or_admin
+on public.profiles
+for insert
+with check (
+  user_id = auth.uid()
+  or public.current_user_has_role('admin')
+);
+
+drop policy if exists profiles_update_self_unlocked_or_admin on public.profiles;
+create policy profiles_update_self_unlocked_or_admin
+on public.profiles
+for update
+using (
+  public.current_user_has_role('admin')
+  or (user_id = auth.uid() and certificate_profile_locked_at is null)
+)
+with check (
+  public.current_user_has_role('admin')
+  or (user_id = auth.uid() and certificate_profile_locked_at is null)
+);
+
+drop policy if exists file_metadata_select_owner_or_staff on public.file_metadata;
+create policy file_metadata_select_owner_or_staff
+on public.file_metadata
+for select
+using (
+  owner_user_id = auth.uid()
+  or public.current_user_has_any_role(array['admin', 'reviewer'])
+);
+
+drop policy if exists file_metadata_insert_owner_or_admin on public.file_metadata;
+create policy file_metadata_insert_owner_or_admin
+on public.file_metadata
+for insert
+with check (
+  owner_user_id = auth.uid()
+  or public.current_user_has_role('admin')
+);
+
+drop policy if exists file_metadata_update_owner_or_admin on public.file_metadata;
+create policy file_metadata_update_owner_or_admin
+on public.file_metadata
+for update
+using (
+  owner_user_id = auth.uid()
+  or public.current_user_has_role('admin')
+)
+with check (
+  owner_user_id = auth.uid()
+  or public.current_user_has_role('admin')
+);
+
+drop policy if exists audit_events_select_self_or_admin on public.audit_events;
+create policy audit_events_select_self_or_admin
+on public.audit_events
+for select
+using (
+  actor_user_id = auth.uid()
+  or target_user_id = auth.uid()
+  or public.current_user_has_role('admin')
+);
+
+drop policy if exists audit_events_insert_authenticated on public.audit_events;
+create policy audit_events_insert_authenticated
+on public.audit_events
+for insert
+with check (auth.uid() is not null);
+
+drop policy if exists storage_private_files_select_owner_or_staff on storage.objects;
+create policy storage_private_files_select_owner_or_staff
+on storage.objects
+for select
+using (
+  bucket_id = 'alp-private-files'
+  and (
+    owner = auth.uid()
+    or public.current_user_has_any_role(array['admin', 'reviewer'])
+  )
+);
+
+drop policy if exists storage_private_files_insert_owner_path on storage.objects;
+create policy storage_private_files_insert_owner_path
+on storage.objects
+for insert
+with check (
+  bucket_id = 'alp-private-files'
+  and owner = auth.uid()
+  and name like auth.uid()::text || '/%'
+);
+
+drop policy if exists storage_private_files_update_owner_path on storage.objects;
+create policy storage_private_files_update_owner_path
+on storage.objects
+for update
+using (
+  bucket_id = 'alp-private-files'
+  and owner = auth.uid()
+  and name like auth.uid()::text || '/%'
+)
+with check (
+  bucket_id = 'alp-private-files'
+  and owner = auth.uid()
+  and name like auth.uid()::text || '/%'
+);
+
+drop policy if exists storage_private_files_delete_owner_or_admin on storage.objects;
+create policy storage_private_files_delete_owner_or_admin
+on storage.objects
+for delete
+using (
+  bucket_id = 'alp-private-files'
+  and (
+    owner = auth.uid()
+    or public.current_user_has_role('admin')
+  )
+);


### PR DESCRIPTION
## Summary

Implements the W1 Auth + Profile + Files schema/security slice after PR #72 authorized W1 entry.

This PR replaces W0 placeholder database artifacts with real W1 schema, private-file metadata, storage bucket expectations, audit hooks, and RLS policies.

## Updates

- Replaces `supabase/migrations/001_alp_auth_profile.sql`
- Adds `supabase/migrations/006_alp_files_certificates_notifications_audit.sql`
- Replaces `supabase/migrations/007_alp_rls_policies.sql`
- Adds W1 evidence at `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md`
- Updates `modules/ALP/11-build/evidence/index.md`
- Updates `modules/ALP/BUILD_PROGRESS_TRACKER.md`

## W1 schema/security scope

This PR covers:

- `learners` base table
- `user_roles` base table with learner/admin/reviewer/course_publisher roles
- `profiles` base table with certificate-critical fields and profile lock guard
- `file_metadata` base table for private profile/file ownership and object paths
- `audit_events` plus profile/file metadata audit hooks
- private `alp-private-files` storage bucket expectation
- RLS policies for learners, roles, profiles, file metadata, audit events, and private storage objects
- helper role-check functions using `auth.uid()`

## Explicit non-scope

This PR does **not** implement:

- login/logout UI
- session handling UI
- protected layouts
- learner profile page/form
- file upload server action
- browser proof
- W1 closure
- W2+ functionality

## Explicit non-claims

This PR does **not** claim:

- W1 closure
- full app delivery
- CODE_PASS
- FUNCTIONAL_PASS
- CWT_PASS
- deployment acceptance
- production readiness

Those remain gated by later W1 app/auth implementation, evidence, checks, and final CWT closure.