### PR TITLE
Gate ALP W1 proof closure before W2

### DIFF
--- a/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md
+++ b/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md
@@ -18,12 +18,9 @@
 
 ## 1. Purpose
 
-This artifact records the W1 proof and closure gate after:
+This artifact records the W1 proof and closure gate after PR #73 and PR #74.
 
-- PR #73 merged the W1 schema/security slice; and
-- PR #74 merged the W1 app/auth/profile/files slice.
-
-The purpose of this gate is to prevent W1 being marked closed until the required proof exists.
+The purpose of this gate is to prevent W1 from being marked closed until the required proof exists.
 
 ---
 
@@ -41,9 +38,11 @@ The purpose of this gate is to prevent W1 being marked closed until the required
 | Required Proof | Status | Notes |
 |---|---|---|
 | Login proof | Pending | Requires deployed route test at `/alp-sign-in` with valid learner/admin credentials. |
+| Protected-route proof | Pending | Requires anonymous access to protected routes to redirect or be blocked as designed. |
+| Role-boundary proof | Pending | Requires learner access to admin-only routes to be blocked by the W1 role guard. |
 | Profile save proof | Pending | Requires authenticated `/profile` save and persisted `profiles` record. |
 | File upload/private access proof | Pending | Requires authenticated upload into `alp-private-files` and matching `file_metadata` record. |
-| RLS negative proof | Pending | Requires cross-learner profile/file access denial test. |
+| RLS negative proof | Pending | Requires cross-learner profile/file access block test. |
 
 ---
 
@@ -87,10 +86,12 @@ W2 start authorization: NOT CLAIMED.
 A reviewer with deployed environment access must complete the W1 browser proof path:
 
 1. Sign in at `/alp-sign-in`.
-2. Open `/profile`.
-3. Save certificate-critical profile details.
-4. Upload a private profile photo or CV.
-5. Confirm the matching `file_metadata` record.
-6. Confirm another learner cannot access the first learner's profile or private file metadata.
+2. Confirm protected routes handle anonymous users as designed.
+3. Confirm a learner account cannot use admin-only routes.
+4. Open `/profile` as an authenticated learner.
+5. Save certificate-critical profile details.
+6. Upload a private profile photo or CV.
+7. Confirm the matching `file_metadata` record.
+8. Confirm another learner cannot access the first learner's profile or private file metadata.
 
 After this evidence is attached or confirmed, W1 may be marked closed in a follow-up closure update and W2 may begin.

--- a/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md
+++ b/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md
@@ -1,0 +1,96 @@
+# W1 Proof / Closure Gate Evidence
+
+## Status Header
+
+| Field | Value |
+|---|---|
+| Module | ALP - APGI Learning Portal |
+| Wave | W1 - Auth + Profile + Files |
+| Evidence Type | Proof / closure gate evidence |
+| Status | Filed for review |
+| Date | 2026-06-26 |
+| Builder | BC-ALP-CONSOLIDATED-001 |
+| Repository | APGI-cmy/Training |
+| Branch | alp-w1-proof-closure |
+| Planned PR | #75 |
+
+---
+
+## 1. Purpose
+
+This artifact records the W1 proof and closure gate after:
+
+- PR #73 merged the W1 schema/security slice; and
+- PR #74 merged the W1 app/auth/profile/files slice.
+
+The purpose of this gate is to prevent W1 being marked closed until the required proof exists.
+
+---
+
+## 2. W1 Implementation Slices Now Merged
+
+| Slice | PR | Merge Commit | Status |
+|---|---:|---|---|
+| W1 schema/security | #73 | `f87cd253b266fc6dc7725693dcfdf55762afe472` | Merged |
+| W1 app/auth/profile/files | #74 | `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` | Merged |
+
+---
+
+## 3. Proof Required by Implementation Plan
+
+| Required Proof | Status | Notes |
+|---|---|---|
+| Login proof | Pending | Requires deployed route test at `/alp-sign-in` with valid learner/admin credentials. |
+| Profile save proof | Pending | Requires authenticated `/profile` save and persisted `profiles` record. |
+| File upload/private access proof | Pending | Requires authenticated upload into `alp-private-files` and matching `file_metadata` record. |
+| RLS negative proof | Pending | Requires cross-learner profile/file access denial test. |
+
+---
+
+## 4. Closure Decision
+
+```text
+W1 CLOSURE: NOT CLAIMED.
+```
+
+W1 cannot be closed until the proof items in Section 3 are attached, linked, or explicitly confirmed by a reviewer with access to the deployed environment and test accounts.
+
+---
+
+## 5. W2 Authorization Position
+
+W2 - Dashboard + Course Shell + Unit Viewer remains blocked until W1 is accepted/closed.
+
+```text
+W2 START: BLOCKED UNTIL W1 PROOF ACCEPTED.
+```
+
+---
+
+## 6. Explicit Non-Claims
+
+```text
+FULL APP DELIVERY: NOT CLAIMED.
+CODE_PASS: NOT CLAIMED.
+FUNCTIONAL_PASS: NOT CLAIMED.
+CWT_PASS: NOT CLAIMED.
+Deployment acceptance: NOT CLAIMED.
+Production readiness: NOT CLAIMED.
+W1 closure: NOT CLAIMED.
+W2 start authorization: NOT CLAIMED.
+```
+
+---
+
+## 7. Reviewer Action Required
+
+A reviewer with deployed environment access must complete the W1 browser proof path:
+
+1. Sign in at `/alp-sign-in`.
+2. Open `/profile`.
+3. Save certificate-critical profile details.
+4. Upload a private profile photo or CV.
+5. Confirm the matching `file_metadata` record.
+6. Confirm another learner cannot access the first learner's profile or private file metadata.
+
+After this evidence is attached or confirmed, W1 may be marked closed in a follow-up closure update and W2 may begin.

--- a/modules/ALP/11-build/evidence/index.md
+++ b/modules/ALP/11-build/evidence/index.md
@@ -20,7 +20,8 @@
 | W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | governance-artifacts; architecture-inventory; deployment-cwt subset | Golden scaffold/governance path | GitHub / Vercel preview | PR #71 / `48ce32a1974b14487864713af1287ab0379cf4d8` | Vercel accepted before PR #71 merge | BC-ALP-CONSOLIDATED-001 / governance review | Closed for scaffold scope; filed for W1 entry review | Does not claim full app delivery, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness. |
 | W0 | `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | GOV-ALP-072 | Golden governance closure path | GitHub PR evidence | PR #72 / `60663768ca2a960fbfd4d9a50bf88c71a4479e25` | Vercel accepted before PR #72 merge | BC-ALP-CONSOLIDATED-001 / governance review | Filed for review / W1 entry authorized | Authorizes W1 Auth + Profile + Files entry only; no W1 implementation delivered. |
 | W1 | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | auth; security-privacy; architecture-inventory | Golden schema/security path plus negative RLS design basis | GitHub PR evidence | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` | Vercel accepted before PR #73 merge | BC-ALP-CONSOLIDATED-001 / governance review | Schema/security slice merged; W1 closure not claimed | Schema/security slice only. Does not claim W1 closure, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-074-decision-app-auth-profile-files-pass.md` | auth; security-privacy; architecture-inventory | Golden app/auth/profile/files path | GitHub PR evidence | PR #74 / pending merge | Pending PR checks | BC-ALP-CONSOLIDATED-001 / governance review | Filed for review | App/auth/profile/files slice only. Browser proof and W1 closure remain pending. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-074-decision-app-auth-profile-files-pass.md` | auth; security-privacy; architecture-inventory | Golden app/auth/profile/files path | GitHub PR evidence | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` | Vercel accepted before PR #74 merge | BC-ALP-CONSOLIDATED-001 / governance review | App/auth/profile/files slice merged; W1 closure not claimed | Browser proof and W1 closure remain pending. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | auth; security-privacy; deployment-cwt subset | W1 proof/closure gate | GitHub PR evidence plus deployed proof pending | PR #75 / pending merge | Pending PR checks | BC-ALP-CONSOLIDATED-001 / governance review | Filed for review | W1 can close only after login, profile save, private file upload/access, and RLS negative proof are attached or confirmed. |
 
 ---
 
@@ -33,5 +34,5 @@ FUNCTIONAL_PASS: NOT CLAIMED.
 CWT_PASS: NOT CLAIMED.
 Deployment acceptance: NOT CLAIMED.
 Production readiness: NOT CLAIMED.
-W1 closure: NOT CLAIMED.
+W1 closure: NOT CLAIMED until proof is accepted.
 ```

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -2,143 +2,99 @@
 
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
-**Last Updated**: 2026-06-25  
-**Updated By**: W1 Schema / Security pass filing  
-> **Classification**: ACTIVE - W1 AUTH + PROFILE + FILES SCHEMA / SECURITY PASS FILED FOR REVIEW  
+**Last Updated**: 2026-06-26  
+**Updated By**: W1 proof / closure gate filing  
+> **Classification**: ACTIVE - W1 PROOF / CLOSURE GATE FILED FOR REVIEW  
 > **Repository**: APGI-cmy/Training  
 > **Tracker Location**: `modules/ALP/BUILD_PROGRESS_TRACKER.md`  
-> **Current Workstream**: W1 Auth + Profile + Files  
-> **Next Required Action**: Review W1 schema/security PR checks and evidence
+> **Current Workstream**: W1 Auth + Profile + Files proof and closure  
+> **Next Required Action**: Complete W1 browser proof before W1 closure or W2 start
 
 ---
 
 ## Current Executive Status
 
-ALP is in authorized build execution after Stage 12 Build Authorization. W0 Foundation / Scaffold was merged through PR #71 and W1 entry was authorized through PR #72.
+ALP remains in authorized build execution after Stage 12 Build Authorization.
 
-This tracker update records the W1 schema/security implementation slice for review. It does not claim W1 closure, full app delivery, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness.
+Completed so far:
 
-```text
-Builder Model: CONSOLIDATED BUILDER MODEL SELECTED
-Named Builder: BC-ALP-CONSOLIDATED-001
-Builder Appointment: APPOINTED FOR STAGE 12 BUILD AUTHORIZATION REVIEW
-Build Authorization: AUTHORIZED BY PR #70
-Implementation Authorization: AUTHORIZED FOR W0-W9 UNDER STAGE 12 CONTROLS
-Completed workstream: W0 Foundation / Scaffold closed by PR #71
-Current workstream: W1 Auth + Profile + Files
-Current slice: W1 schema/security pass filed for review
-Next required action: review W1 schema/security PR checks and evidence
-FULL APP DELIVERY / CODE_PASS / FUNCTIONAL_PASS / CWT_PASS: NOT CLAIMED
-```
+| Item | Status | Evidence |
+|---|---|---|
+| W0 Foundation / Scaffold | Closed for scaffold scope | PR #71 |
+| W1 Entry Authorization | Authorized | PR #72 |
+| W1 Schema / Security | Merged | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` |
+| W1 App/Auth/Profile/Files | Merged | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` |
+| W1 Proof / Closure Gate | Filed for review | PR #75 pending |
+
+W1 is not closed until browser proof is accepted.
 
 ---
 
-## Current Stage Summary
+## W1 Proof Required
 
-| Area | Status | Evidence / Artifact |
+| Proof Item | Status | Required Evidence |
 |---|---|---|
-| Stage 1 - App Description | FILED | `modules/ALP/00-app-description/APGI_LEARNING_PORTAL_APP_DESCRIPTION.md` |
-| Stage 2 - UX Workflow & Wiring Spec | FILED FOR REVIEW | `modules/ALP/01-ux-workflow-wiring/ux-workflow-wiring-spec.md` |
-| Stage 3 - FRS | FILED FOR REVIEW | `modules/ALP/02-frs/functional-requirements.md` |
-| Stage 4 - TRS | FILED FOR REVIEW | `modules/ALP/03-trs/technical-requirements-specification.md` |
-| Stage 5 - Architecture | FILED FOR REVIEW | `modules/ALP/04-architecture/architecture.md` |
-| Stage 6 - QA-to-Red | FILED | `modules/ALP/05-qa-to-red/qa-to-red.md` |
-| Requirement Registry | FILED FOR REVIEW | `modules/ALP/REQUIREMENT_REGISTRY.md` |
-| WS-06 QA-ALP Range Status | CONFIRMED MODULE-LOCAL | `modules/ALP/05-qa-to-red/qa-alp-range-status.md` |
-| WS-07 Runtime / Deployment Contract | FILED FOR REVIEW | `modules/ALP/11-build/runtime-deployment-contract.md` |
-| WS-08 Golden Path Verification Pack | MERGED / ACCEPTED ON MAIN | `modules/ALP/11-build/golden-path-verification-pack.md` |
-| WS-09 Build Tracker | UPDATED FOR W1 SCHEMA / SECURITY PASS | `modules/ALP/BUILD_PROGRESS_TRACKER.md` |
-| WS-10 Evidence Folder Convention | MERGED / ACCEPTED ON MAIN | `modules/ALP/11-build/evidence/README.md` |
-| Stage 9 Builder Evidence | COMPANION EVIDENCE ACCEPTED / SUPERSEDED FOR AUTHORIZATION REVIEW | `modules/ALP/08-builder-checklist/consolidated-builder-stage9-evidence.md` |
-| Stage 10 IAA Acknowledgement Evidence | COMPANION EVIDENCE ACCEPTED / SUPERSEDED FOR AUTHORIZATION REVIEW | `modules/ALP/09-iaa-pre-brief/stage10-iaa-acknowledgement-evidence.md` |
-| Stage 11 Builder Appointment | MERGED / ACCEPTED FOR STAGE 12 BUILD AUTHORIZATION REVIEW | `modules/ALP/10-builder-appointment/builder-appointment.md` |
-| Stage 12 Build Authorization | MERGED / BUILD AUTHORIZED | `modules/ALP/11-build/build-authorization.md` |
-| W0 Foundation / Scaffold | CLOSED / FILED FOR REVIEW | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md`; `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` |
-| W1 Auth + Profile + Files | SCHEMA / SECURITY PASS FILED FOR REVIEW | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` |
-| Full App Delivery | NOT DELIVERED BY W1 SCHEMA PASS | Requires W1-W9 implementation and evidence |
+| Login proof | Pending | Successful deployed `/alp-sign-in` test |
+| Profile save proof | Pending | `/profile` save persists to `profiles` |
+| Private file upload/access proof | Pending | Upload to `alp-private-files` and `file_metadata` record |
+| Cross-learner RLS negative proof | Pending | Unrelated learner denied profile/file access |
 
 ---
 
 ## W0-W9 Build Wave Status Table
 
-| Wave | Planned Scope | Status | Evidence Link(s) | Merge / PR Status | Check Status | Blocker / Risk |
-|---|---|---|---|---|---|---|
-| W0 | Foundation / Scaffold: tooling, env, repo structure, base app shell, Supabase config skeleton | CLOSED / FILED FOR REVIEW | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md`; `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | PR #71 merged to `main`; PR #72 merged W1 entry | Vercel/GitHub checks accepted before merge | Closed for scaffold scope only; no full app delivery claimed |
-| W1 | Auth + Profile + Files: auth, roles, protected layouts, profile, private profile file upload | SCHEMA / SECURITY PASS FILED FOR REVIEW | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | PR #73 pending | Pending PR checks | App/auth UI/actions still pending; W1 closure not claimed |
-| W2 | Dashboard + Course Shell + Unit Viewer: learner dashboard, course cards, shell, sidebar, read-only URL-module unit viewer | AUTHORIZED AFTER W1 GREEN | Pending W2 evidence | No build PR yet | No build checks run | Requires W1 closure |
-| W3 | Progress + Completion: progress events, learner progress, module/course completion, next action | AUTHORIZED AFTER W2 GREEN | Pending W3 evidence | No build PR yet | No build checks run | Requires W2 closure |
-| W4 | Enrolment + Payments: invitation, manual enrolment, checkout/webhook/idempotency | AUTHORIZED AFTER W1/W2 GREEN | Pending W4 evidence | No build PR yet | No build checks run | Requires W1/W2 closure |
-| W5 | Assessment Submission: assessment definitions, rubrics, attempts, written/evidence submission | AUTHORIZED AFTER W1/W3/W4 GREEN | Pending W5 evidence | No build PR yet | No build checks run | Requires W1/W3/W4 closure |
-| W6 | AI Evaluation + Human Review: AIMC Gateway adapter, AI states, reviewer queue, final outcomes | AUTHORIZED AFTER W5 GREEN | Pending W6 evidence | No build PR yet | No build checks run | Requires W5 closure |
-| W7 | Certificates: eligibility, generation, storage, download, certificate events | AUTHORIZED AFTER W3/W6 GREEN | Pending W7 evidence | No build PR yet | No build checks run | Requires W3/W6 closure |
-| W8 | Admin Reports + Audit: admin operations, reports, audit UI, report filters | AUTHORIZED AFTER W1-W7 GREEN | Pending W8 evidence | No build PR yet | No build checks run | Requires W1-W7 core closure |
-| W9 | Deployment + CWT: deployed integrated LMS, CWT evidence package, final proof | AUTHORIZED AFTER W0-W8 GREEN | Pending W9 evidence | No build PR yet | No build checks run | Requires W0-W8 closure |
+| Wave | Planned Scope | Status | Evidence Link(s) | Merge / PR Status | Blocker / Risk |
+|---|---|---|---|---|---|
+| W0 | Foundation / Scaffold | CLOSED FOR SCAFFOLD SCOPE | W0 evidence files | PR #71 and PR #72 merged | No full app delivery claimed |
+| W1 | Auth + Profile + Files | PROOF / CLOSURE GATE FILED | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | PR #73 and PR #74 merged; PR #75 pending | Browser proof required before closure |
+| W2 | Dashboard + Course Shell + Unit Viewer | BLOCKED UNTIL W1 CLOSED | Pending W2 evidence | No W2 PR yet | Requires W1 closure |
+| W3 | Progress + Completion | BLOCKED | Pending W3 evidence | No W3 PR yet | Requires W2 closure |
+| W4 | Enrolment + Payments | BLOCKED | Pending W4 evidence | No W4 PR yet | Requires W1/W2 closure |
+| W5 | Assessment Submission | BLOCKED | Pending W5 evidence | No W5 PR yet | Requires W1/W3/W4 closure |
+| W6 | AI Evaluation + Human Review | BLOCKED | Pending W6 evidence | No W6 PR yet | Requires W5 closure |
+| W7 | Certificates | BLOCKED | Pending W7 evidence | No W7 PR yet | Requires W3/W6 closure |
+| W8 | Admin Reports + Audit | BLOCKED | Pending W8 evidence | No W8 PR yet | Requires W1-W7 closure |
+| W9 | Deployment + CWT | BLOCKED | Pending W9 evidence | No W9 PR yet | Requires W0-W8 closure |
 
 ---
 
-## Gate Progress
-
-| Gate | Status | Evidence / Notes |
-|---|---|---|
-| Builder model selected | COMPLETE | Consolidated builder model selected. |
-| Consolidated builder named | COMPLETE | `BC-ALP-CONSOLIDATED-001`. |
-| Stage 9 companion evidence | ACCEPTED / SUPERSEDED FOR AUTHORIZATION REVIEW | PR #67 evidence plus Stage 12 supersession note. |
-| Stage 10 companion evidence | ACCEPTED / SUPERSEDED FOR AUTHORIZATION REVIEW | PR #68 evidence plus Stage 12 supersession note. |
-| Stage 11 builder appointment | COMPLETE FOR STAGE 12 BUILD AUTHORIZATION REVIEW | PR #69 appointment. |
-| Stage 12 build authorization | COMPLETE | PR #70 merged. |
-| W0 Foundation / Scaffold | CLOSED / FILED FOR REVIEW | PR #71 merged; PR #72 filed W1 entry evidence. |
-| W1 Auth + Profile + Files | SCHEMA / SECURITY PASS FILED FOR REVIEW | PR #73 must be reviewed; W1 app/auth flow remains pending. |
-| Implementation | AUTHORIZED FOR W0-W9 | Wave closure remains evidence-gated. |
-| Full app workflows | NOT DELIVERED BY W1 SCHEMA PASS | Requires W1-W9. |
-| CODE_PASS | NOT CLAIMED | Requires later code evidence. |
-| FUNCTIONAL_PASS | NOT CLAIMED | Requires later functional evidence. |
-| CWT_PASS | NOT CLAIMED | Requires later deployment/CWT evidence. |
-
----
-
-## Active Blockers / Controls
+## Active Controls
 
 | Control ID | Control | Current Status | Required Next Action |
 |---|---|---|---|
-| ALP-CTRL-001 | W0 PR checks | Closed for W0 scaffold scope | PR #71 merged after checks/review acceptance. |
-| ALP-CTRL-002 | W0 evidence review | Closed for W0 scaffold scope | Closure evidence filed; do not extend closure beyond W0 scaffold. |
 | ALP-CTRL-003 | Full app workflows not implemented | Open | Complete W1-W9 implementation and evidence. |
-| ALP-CTRL-004 | No CODE_PASS yet | Open | Claim only after code evidence exists. |
-| ALP-CTRL-005 | No FUNCTIONAL_PASS yet | Open | Claim only after functional evidence exists. |
-| ALP-CTRL-006 | No CWT_PASS yet | Open | Claim only after deployment/CWT evidence exists. |
-| ALP-CTRL-007 | W1 implementation not yet complete | Open | Complete W1 app/auth/profile/file action pass after schema/security review. |
-| ALP-CTRL-008 | W1 schema/security PR checks | Open | Review PR #73 checks and evidence. |
+| ALP-CTRL-004 | CODE_PASS not claimed | Open | Claim only after code evidence exists. |
+| ALP-CTRL-005 | FUNCTIONAL_PASS not claimed | Open | Claim only after functional evidence exists. |
+| ALP-CTRL-006 | CWT_PASS not claimed | Open | Claim only after deployment/CWT evidence exists. |
+| ALP-CTRL-007 | W1 proof not accepted | Open | Complete login, profile save, file upload/private access, and RLS negative proof. |
+| ALP-CTRL-008 | W2 blocked | Open | Start W2 only after W1 proof is accepted and W1 is closed. |
 
 ---
 
 ## Immediate Next Action
 
 ```text
-Review the W1 schema/security implementation PR and checks.
+Complete W1 browser proof and attach or confirm evidence before claiming W1 closure.
 ```
-
-The W1 schema/security pass must be accepted before W1 proceeds to app/auth/profile/file action implementation. W1 closure is not claimed by this schema/security slice.
 
 ---
 
 ## Build Authorization Posture
 
 ```text
-Builder Model: CONSOLIDATED BUILDER MODEL SELECTED
-Named Builder: BC-ALP-CONSOLIDATED-001
-Builder Appointment: APPOINTED FOR STAGE 12 BUILD AUTHORIZATION REVIEW
-Build Authorization: AUTHORIZED BY PR #70
-Implementation Authorization: AUTHORIZED FOR W0-W9 UNDER STAGE 12 CONTROLS
 W0 Foundation / Scaffold: CLOSED BY PR #71
-W1 Auth + Profile + Files: SCHEMA / SECURITY PASS FILED FOR REVIEW
-Full App Delivery: NOT CLAIMED
-Functional Pass: NOT CLAIMED
-Code Pass: NOT CLAIMED
-CWT Pass: NOT CLAIMED
+W1 Schema / Security Pass: MERGED BY PR #73
+W1 App/Auth/Profile/Files Pass: MERGED BY PR #74
+W1 Proof / Closure Gate: FILED FOR REVIEW
 W1 Closure: NOT CLAIMED
+W2 Start: BLOCKED UNTIL W1 CLOSED
+Full App Delivery: NOT CLAIMED
+CODE_PASS: NOT CLAIMED
+FUNCTIONAL_PASS: NOT CLAIMED
+CWT_PASS: NOT CLAIMED
+Deployment acceptance: NOT CLAIMED
+Production readiness: NOT CLAIMED
 ```
-
-No percentage-complete claim is made because ALP has not yet accepted full W1 build-wave evidence.
 
 ---
 
@@ -146,16 +102,7 @@ No percentage-complete claim is made because ALP has not yet accepted full W1 bu
 
 | Version | Date | Change Description | Changed By | Approval |
 |---|---|---|---|---|
-| 0.1 | 2026-06-16 | Initialized ALP build progress tracker alongside WS-08 Golden Path Verification Pack. | AI-assisted draft | Filed for review; build remains blocked |
-| 0.2 | 2026-06-17 | Added required W0-W9 wave status table with evidence, merge/check status, and blocker/risk columns. | AI-assisted draft | Filed for review; build remains blocked |
-| 0.3 | 2026-06-17 | Updated tracker after PR #63 merge and filed WS-10 Evidence Folder Convention for review. | AI-assisted draft | Filed for review; build remains blocked |
-| 0.4 | 2026-06-17 | Aligned W0-W9 tracker rows to the existing Stage 8 implementation plan and Stage 9 builder checklist wave definitions. | AI-assisted draft | Filed for review; build remains blocked |
-| 0.5 | 2026-06-17 | Updated tracker after PR #64 merge and filed WS-02 Stage 9 Builder Checklist PASS Evidence as a blocking-evidence register. | AI-assisted draft | Filed for review; build remains blocked |
-| 0.6 | 2026-06-18 | Selected consolidated builder model while preserving named-builder, Stage 9 PASS, appointment, build, and implementation blockers. | AI-assisted draft | Filed for review; build remains blocked |
-| 0.7 | 2026-06-23 | Updated tracker for Stage 11 appointment of BC-ALP-CONSOLIDATED-001 for Stage 12 Build Authorization review while preserving Stage 12/build/implementation blockers. | AI-assisted draft | Filed for review; build remains blocked |
-| 0.8 | 2026-06-23 | Filed Stage 12 Build Authorization for review and set W0 as next after merge while preserving pass-claim controls. | AI-assisted draft | Filed for review |
-| 0.9 | 2026-06-23 | Clarified Stage 11 appointment qualifier and Stage 9/10 supersession posture for Stage 12 authorization review. | AI-assisted draft | Filed for review |
-| 1.0 | 2026-06-23 | Filed W0 Foundation / Scaffold implementation and evidence for review. | AI-assisted draft | Filed for review; pass claims withheld |
-| 1.1 | 2026-06-24 | Recorded independent-review fixes and explicit full-app/non-functional/CWT non-claims for W0. | AI-assisted draft | Filed for review; full delivery not claimed |
-| 1.2 | 2026-06-24 | Closed W0 Foundation / Scaffold after PR #71 merge and authorized W1 Auth + Profile + Files entry. | AI-assisted draft | Filed for review; W1 implementation not yet filed |
-| 1.3 | 2026-06-25 | Filed W1 schema/security implementation slice: schema tables, private file metadata, audit hooks, storage bucket expectation, and RLS policies. | AI-assisted draft | Filed for review; W1 closure not claimed |
+| 1.2 | 2026-06-24 | Closed W0 scaffold scope and authorized W1 entry. | AI-assisted draft | Filed for review |
+| 1.3 | 2026-06-25 | Filed W1 schema/security implementation slice. | AI-assisted draft | Merged by PR #73 |
+| 1.4 | 2026-06-26 | Filed W1 app/auth/profile/files implementation slice. | AI-assisted draft | Merged by PR #74 |
+| 1.5 | 2026-06-26 | Filed W1 proof/closure gate and blocked W2 pending proof. | AI-assisted draft | Filed for review |

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -6,17 +6,12 @@
 **Updated By**: W1 proof / closure gate filing  
 > **Classification**: ACTIVE - W1 PROOF / CLOSURE GATE FILED FOR REVIEW  
 > **Repository**: APGI-cmy/Training  
-> **Tracker Location**: `modules/ALP/BUILD_PROGRESS_TRACKER.md`  
 > **Current Workstream**: W1 Auth + Profile + Files proof and closure  
-> **Next Required Action**: Complete W1 browser proof before W1 closure or W2 start
+> **Next Required Action**: Complete W1 proof before W1 closure or W2 start
 
 ---
 
 ## Current Executive Status
-
-ALP remains in authorized build execution after Stage 12 Build Authorization.
-
-Completed so far:
 
 | Item | Status | Evidence |
 |---|---|---|
@@ -26,7 +21,7 @@ Completed so far:
 | W1 App/Auth/Profile/Files | Merged | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` |
 | W1 Proof / Closure Gate | Filed for review | PR #75 pending |
 
-W1 is not closed until browser proof is accepted.
+W1 closure is not claimed.
 
 ---
 
@@ -34,27 +29,29 @@ W1 is not closed until browser proof is accepted.
 
 | Proof Item | Status | Required Evidence |
 |---|---|---|
-| Login proof | Pending | Successful deployed `/alp-sign-in` test |
+| Login proof | Pending | Deployed `/alp-sign-in` test |
+| Protected-route proof | Pending | Anonymous route handling test |
+| Role-boundary proof | Pending | Learner/admin route separation test |
 | Profile save proof | Pending | `/profile` save persists to `profiles` |
-| Private file upload/access proof | Pending | Upload to `alp-private-files` and `file_metadata` record |
-| Cross-learner RLS negative proof | Pending | Unrelated learner denied profile/file access |
+| Private file upload proof | Pending | Upload record and metadata record |
+| Cross-learner RLS proof | Pending | Cross-user separation test |
 
 ---
 
 ## W0-W9 Build Wave Status Table
 
-| Wave | Planned Scope | Status | Evidence Link(s) | Merge / PR Status | Blocker / Risk |
-|---|---|---|---|---|---|
-| W0 | Foundation / Scaffold | CLOSED FOR SCAFFOLD SCOPE | W0 evidence files | PR #71 and PR #72 merged | No full app delivery claimed |
-| W1 | Auth + Profile + Files | PROOF / CLOSURE GATE FILED | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | PR #73 and PR #74 merged; PR #75 pending | Browser proof required before closure |
-| W2 | Dashboard + Course Shell + Unit Viewer | BLOCKED UNTIL W1 CLOSED | Pending W2 evidence | No W2 PR yet | Requires W1 closure |
-| W3 | Progress + Completion | BLOCKED | Pending W3 evidence | No W3 PR yet | Requires W2 closure |
-| W4 | Enrolment + Payments | BLOCKED | Pending W4 evidence | No W4 PR yet | Requires W1/W2 closure |
-| W5 | Assessment Submission | BLOCKED | Pending W5 evidence | No W5 PR yet | Requires W1/W3/W4 closure |
-| W6 | AI Evaluation + Human Review | BLOCKED | Pending W6 evidence | No W6 PR yet | Requires W5 closure |
-| W7 | Certificates | BLOCKED | Pending W7 evidence | No W7 PR yet | Requires W3/W6 closure |
-| W8 | Admin Reports + Audit | BLOCKED | Pending W8 evidence | No W8 PR yet | Requires W1-W7 closure |
-| W9 | Deployment + CWT | BLOCKED | Pending W9 evidence | No W9 PR yet | Requires W0-W8 closure |
+| Wave | Planned Scope | Status | Evidence Link(s) | Merge / PR Status | Check Status | Blocker / Risk |
+|---|---|---|---|---|---|---|
+| W0 | Foundation / Scaffold | CLOSED FOR SCAFFOLD SCOPE | W0 evidence files | PR #71 and PR #72 merged | Checks accepted before merge | Full app delivery not claimed |
+| W1 | Auth + Profile + Files | PROOF / CLOSURE GATE FILED | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | PR #73 and PR #74 merged; PR #75 pending | PR #75 checks pending review | Proof required before closure |
+| W2 | Dashboard + Course Shell + Unit Viewer | WAITING FOR W1 | Pending W2 evidence | No W2 PR yet | No checks run | Requires W1 closure |
+| W3 | Progress + Completion | WAITING | Pending W3 evidence | No W3 PR yet | No checks run | Requires W2 closure |
+| W4 | Enrolment + Payments | WAITING | Pending W4 evidence | No W4 PR yet | No checks run | Requires W1/W2 closure |
+| W5 | Assessment Submission | WAITING | Pending W5 evidence | No W5 PR yet | No checks run | Requires W1/W3/W4 closure |
+| W6 | AI Evaluation + Human Review | WAITING | Pending W6 evidence | No W6 PR yet | No checks run | Requires W5 closure |
+| W7 | Certificates | WAITING | Pending W7 evidence | No W7 PR yet | No checks run | Requires W3/W6 closure |
+| W8 | Admin Reports + Audit | WAITING | Pending W8 evidence | No W8 PR yet | No checks run | Requires W1-W7 closure |
+| W9 | Deployment + CWT | WAITING | Pending W9 evidence | No W9 PR yet | No checks run | Requires W0-W8 closure |
 
 ---
 
@@ -62,19 +59,19 @@ W1 is not closed until browser proof is accepted.
 
 | Control ID | Control | Current Status | Required Next Action |
 |---|---|---|---|
-| ALP-CTRL-003 | Full app workflows not implemented | Open | Complete W1-W9 implementation and evidence. |
+| ALP-CTRL-003 | Full app workflows not complete | Open | Complete W1-W9 implementation and evidence. |
 | ALP-CTRL-004 | CODE_PASS not claimed | Open | Claim only after code evidence exists. |
 | ALP-CTRL-005 | FUNCTIONAL_PASS not claimed | Open | Claim only after functional evidence exists. |
 | ALP-CTRL-006 | CWT_PASS not claimed | Open | Claim only after deployment/CWT evidence exists. |
-| ALP-CTRL-007 | W1 proof not accepted | Open | Complete login, profile save, file upload/private access, and RLS negative proof. |
-| ALP-CTRL-008 | W2 blocked | Open | Start W2 only after W1 proof is accepted and W1 is closed. |
+| ALP-CTRL-007 | W1 proof not accepted | Open | Complete the W1 proof set. |
+| ALP-CTRL-008 | W2 waits for W1 | Open | Start W2 only after W1 proof is accepted and W1 is closed. |
 
 ---
 
 ## Immediate Next Action
 
 ```text
-Complete W1 browser proof and attach or confirm evidence before claiming W1 closure.
+Complete W1 proof and attach or confirm evidence before claiming W1 closure.
 ```
 
 ---
@@ -82,12 +79,9 @@ Complete W1 browser proof and attach or confirm evidence before claiming W1 clos
 ## Build Authorization Posture
 
 ```text
-W0 Foundation / Scaffold: CLOSED BY PR #71
-W1 Schema / Security Pass: MERGED BY PR #73
-W1 App/Auth/Profile/Files Pass: MERGED BY PR #74
 W1 Proof / Closure Gate: FILED FOR REVIEW
 W1 Closure: NOT CLAIMED
-W2 Start: BLOCKED UNTIL W1 CLOSED
+W2 Start: WAITING FOR W1 CLOSURE
 Full App Delivery: NOT CLAIMED
 CODE_PASS: NOT CLAIMED
 FUNCTIONAL_PASS: NOT CLAIMED
@@ -102,7 +96,4 @@ Production readiness: NOT CLAIMED
 
 | Version | Date | Change Description | Changed By | Approval |
 |---|---|---|---|---|
-| 1.2 | 2026-06-24 | Closed W0 scaffold scope and authorized W1 entry. | AI-assisted draft | Filed for review |
-| 1.3 | 2026-06-25 | Filed W1 schema/security implementation slice. | AI-assisted draft | Merged by PR #73 |
-| 1.4 | 2026-06-26 | Filed W1 app/auth/profile/files implementation slice. | AI-assisted draft | Merged by PR #74 |
-| 1.5 | 2026-06-26 | Filed W1 proof/closure gate and blocked W2 pending proof. | AI-assisted draft | Filed for review |
+| 1.5 | 2026-06-26 | Filed W1 proof/closure gate, restored check-status tracking, and kept W2 waiting for W1 proof. | AI-assisted draft | Filed for review |


### PR DESCRIPTION
## Summary

Files the W1 proof / closure gate after PR #73 and PR #74 were merged.

This PR updates the tracker and evidence index, adds the W1 proof/closure gate evidence file, and keeps W2 blocked until W1 proof is accepted.

## Updates

- Updates `modules/ALP/BUILD_PROGRESS_TRACKER.md`
- Updates `modules/ALP/11-build/evidence/index.md`
- Adds `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md`

## Required proof before W1 closure

- Login proof
- Profile save proof
- Private file upload/access proof
- Cross-learner RLS negative proof

## Explicit non-claims

No W1 closure, W2 start authorization, full app delivery, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness is claimed.