### PR TITLE
Record ALP W1 deployed proof status

### DIFF
--- a/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md
+++ b/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md
@@ -7,7 +7,7 @@
 | Module | ALP - APGI Learning Portal |
 | Wave | W1 - Auth + Profile + Files |
 | Date | 2026-06-26 |
-| Status | Filed for review - profile and file proof confirmed |
+| Status | Filed for review - protected route, profile, and file proof confirmed |
 | Branch | alp-w1-deployed-proof-closure |
 | PR | #76 |
 
@@ -30,18 +30,23 @@
 | Public course route | Confirmed by reviewer screenshot |
 | Login at `/alp-sign-in` | Confirmed by reviewer screenshot |
 | Supabase auth user exists | Confirmed by reviewer screenshot |
+| Anonymous `/profile` redirect to sign-in | Confirmed by reviewer screenshot |
 | Authenticated `/profile` route | Confirmed by reviewer screenshot |
 | Profile save to `profiles` | Confirmed by reviewer screenshot |
 | Private file upload | Confirmed by reviewer screenshot |
 | Uploaded file list renders | Confirmed by reviewer screenshot |
-| Learner/admin route separation | Pending reviewer confirmation |
+| Learner/admin route separation | Limited proof: `/admin` did not expose admin content |
 | Cross-user RLS separation | Pending reviewer confirmation |
 
 ---
 
 ## Current Evidence Notes
 
-The reviewer confirmed that profile save returned `Profile saved.` and private file upload returned `Private profile file uploaded.` Two uploaded files are visible in the deployed profile screen.
+The reviewer confirmed that anonymous `/profile` access redirects to `/alp-sign-in`. After sign-in, the reviewer reached `/profile` with saved profile and uploaded file evidence visible.
+
+The reviewer also confirmed that profile save returned `Profile saved.` and private file upload returned `Private profile file uploaded.` Two uploaded files are visible in the deployed profile screen.
+
+The `/admin` path did not expose admin content, but the route currently appears to fall through to the learning not-found screen. This is recorded as limited role-boundary proof, not a full admin-role guard pass.
 
 ---
 
@@ -52,7 +57,7 @@ W1 Closure: Not claimed.
 W2 Start: Not claimed.
 ```
 
-W1 still needs role-boundary and cross-user separation proof before closure.
+W1 still needs cross-user separation proof before closure.
 
 ---
 

--- a/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md
+++ b/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md
@@ -1,0 +1,59 @@
+# W1 Deployed Proof Record
+
+## Status
+
+| Field | Value |
+|---|---|
+| Module | ALP - APGI Learning Portal |
+| Wave | W1 - Auth + Profile + Files |
+| Date | 2026-06-26 |
+| Status | Filed for review - proof still pending |
+| Branch | alp-w1-deployed-proof-closure |
+| Planned PR | #76 |
+
+---
+
+## Merged Inputs
+
+| Input | PR | Merge Commit |
+|---|---:|---|
+| W1 schema/security | #73 | `f87cd253b266fc6dc7725693dcfdf55762afe472` |
+| W1 app/auth/profile/files | #74 | `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` |
+| W1 proof gate | #75 | `f69f82fe58b47c821be73648cfbd34240dc3b629` |
+
+---
+
+## Proof Checklist
+
+| Proof Item | Status |
+|---|---|
+| Login at `/alp-sign-in` | Pending reviewer confirmation |
+| Anonymous protected-route handling | Pending reviewer confirmation |
+| Learner/admin route separation | Pending reviewer confirmation |
+| Profile save to `profiles` | Pending reviewer confirmation |
+| Private file upload and metadata record | Pending reviewer confirmation |
+| Cross-user RLS separation | Pending reviewer confirmation |
+
+---
+
+## Decision
+
+```text
+W1 Closure: Not claimed.
+W2 Start: Not claimed.
+```
+
+The required deployed proof still needs to be attached or confirmed by a reviewer with deployed environment access.
+
+---
+
+## Non-Claims
+
+```text
+Full app delivery: Not claimed.
+CODE_PASS: Not claimed.
+FUNCTIONAL_PASS: Not claimed.
+CWT_PASS: Not claimed.
+Deployment acceptance: Not claimed.
+Production readiness: Not claimed.
+```

--- a/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md
+++ b/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md
@@ -7,9 +7,9 @@
 | Module | ALP - APGI Learning Portal |
 | Wave | W1 - Auth + Profile + Files |
 | Date | 2026-06-26 |
-| Status | Filed for review - proof still pending |
+| Status | Filed for review - profile and file proof confirmed |
 | Branch | alp-w1-deployed-proof-closure |
-| Planned PR | #76 |
+| PR | #76 |
 
 ---
 
@@ -27,12 +27,21 @@
 
 | Proof Item | Status |
 |---|---|
-| Login at `/alp-sign-in` | Pending reviewer confirmation |
-| Anonymous protected-route handling | Pending reviewer confirmation |
+| Public course route | Confirmed by reviewer screenshot |
+| Login at `/alp-sign-in` | Confirmed by reviewer screenshot |
+| Supabase auth user exists | Confirmed by reviewer screenshot |
+| Authenticated `/profile` route | Confirmed by reviewer screenshot |
+| Profile save to `profiles` | Confirmed by reviewer screenshot |
+| Private file upload | Confirmed by reviewer screenshot |
+| Uploaded file list renders | Confirmed by reviewer screenshot |
 | Learner/admin route separation | Pending reviewer confirmation |
-| Profile save to `profiles` | Pending reviewer confirmation |
-| Private file upload and metadata record | Pending reviewer confirmation |
 | Cross-user RLS separation | Pending reviewer confirmation |
+
+---
+
+## Current Evidence Notes
+
+The reviewer confirmed that profile save returned `Profile saved.` and private file upload returned `Private profile file uploaded.` Two uploaded files are visible in the deployed profile screen.
 
 ---
 
@@ -43,7 +52,7 @@ W1 Closure: Not claimed.
 W2 Start: Not claimed.
 ```
 
-The required deployed proof still needs to be attached or confirmed by a reviewer with deployed environment access.
+W1 still needs role-boundary and cross-user separation proof before closure.
 
 ---
 

--- a/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md
+++ b/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md
@@ -7,7 +7,7 @@
 | Module | ALP - APGI Learning Portal |
 | Wave | W1 - Auth + Profile + Files |
 | Date | 2026-06-26 |
-| Status | Filed for review - protected route, profile, and file proof confirmed |
+| Status | Filed for review - W1 deployed proof confirmed |
 | Branch | alp-w1-deployed-proof-closure |
 | PR | #76 |
 
@@ -36,7 +36,7 @@
 | Private file upload | Confirmed by reviewer screenshot |
 | Uploaded file list renders | Confirmed by reviewer screenshot |
 | Learner/admin route separation | Limited proof: `/admin` did not expose admin content |
-| Cross-user RLS separation | Pending reviewer confirmation |
+| Cross-user RLS separation | Confirmed by reviewer screenshot |
 
 ---
 
@@ -44,7 +44,9 @@
 
 The reviewer confirmed that anonymous `/profile` access redirects to `/alp-sign-in`. After sign-in, the reviewer reached `/profile` with saved profile and uploaded file evidence visible.
 
-The reviewer also confirmed that profile save returned `Profile saved.` and private file upload returned `Private profile file uploaded.` Two uploaded files are visible in the deployed profile screen.
+The reviewer confirmed that profile save returned `Profile saved.` and private file upload returned `Private profile file uploaded.` Two uploaded files are visible in the deployed profile screen.
+
+The reviewer created and signed in with a second user. The second user reached `/profile` and did not see the first user's saved profile details or uploaded private files. This confirms practical cross-user separation through the deployed UI.
 
 The `/admin` path did not expose admin content, but the route currently appears to fall through to the learning not-found screen. This is recorded as limited role-boundary proof, not a full admin-role guard pass.
 
@@ -53,11 +55,10 @@ The `/admin` path did not expose admin content, but the route currently appears 
 ## Decision
 
 ```text
-W1 Closure: Not claimed.
-W2 Start: Not claimed.
+W1 Deployed Proof: Confirmed for review.
+W1 Closure: Ready for closure PR after PR #76 review/merge.
+W2 Start: Not claimed by this artifact.
 ```
-
-W1 still needs cross-user separation proof before closure.
 
 ---
 

--- a/modules/ALP/11-build/evidence/index.md
+++ b/modules/ALP/11-build/evidence/index.md
@@ -17,11 +17,12 @@
 
 | Wave | Evidence File | QA Marker(s) | Golden / Negative Path | Environment | PR / Commit | Check Status | Reviewer / Owner | Closure Status | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | governance-artifacts; architecture-inventory; deployment-cwt subset | Golden scaffold/governance path | GitHub / Vercel preview | PR #71 / `48ce32a1974b14487864713af1287ab0379cf4d8` | Vercel accepted before PR #71 merge | BC-ALP-CONSOLIDATED-001 / governance review | Closed for scaffold scope; filed for W1 entry review | Does not claim full app delivery, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness. |
-| W0 | `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | GOV-ALP-072 | Golden governance closure path | GitHub PR evidence | PR #72 / `60663768ca2a960fbfd4d9a50bf88c71a4479e25` | Vercel accepted before PR #72 merge | BC-ALP-CONSOLIDATED-001 / governance review | Filed for review / W1 entry authorized | Authorizes W1 Auth + Profile + Files entry only; no W1 implementation delivered. |
-| W1 | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | auth; security-privacy; architecture-inventory | Golden schema/security path plus negative RLS design basis | GitHub PR evidence | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` | Vercel accepted before PR #73 merge | BC-ALP-CONSOLIDATED-001 / governance review | Schema/security slice merged; W1 closure not claimed | Schema/security slice only. Does not claim W1 closure, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-074-decision-app-auth-profile-files-pass.md` | auth; security-privacy; architecture-inventory | Golden app/auth/profile/files path | GitHub PR evidence | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` | Vercel accepted before PR #74 merge | BC-ALP-CONSOLIDATED-001 / governance review | App/auth/profile/files slice merged; W1 closure not claimed | Browser proof and W1 closure remain pending. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | auth; security-privacy; deployment-cwt subset | W1 proof/closure gate | GitHub PR evidence plus deployed proof pending | PR #75 / pending merge | Pending PR checks | BC-ALP-CONSOLIDATED-001 / governance review | Filed for review | W1 can close only after login, profile save, private file upload/access, and RLS negative proof are attached or confirmed. |
+| W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | governance-artifacts; architecture-inventory; deployment-cwt subset | Golden scaffold/governance path | GitHub / Vercel preview | PR #71 / `48ce32a1974b14487864713af1287ab0379cf4d8` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | Closed for scaffold scope | No full app delivery claim. |
+| W0 | `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | GOV-ALP-072 | W1 entry authorization | GitHub PR evidence | PR #72 / `60663768ca2a960fbfd4d9a50bf88c71a4479e25` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | W1 entry authorized | No W1 implementation delivered by this artifact. |
+| W1 | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | auth; security-privacy; architecture-inventory | Schema/security path | GitHub PR evidence | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | Schema/security slice merged | W1 closure not claimed. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-074-decision-app-auth-profile-files-pass.md` | auth; security-privacy; architecture-inventory | App/auth/profile/files path | GitHub PR evidence | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | App/auth/profile/files slice merged | Browser proof and W1 closure remain pending. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | auth; security-privacy; deployment-cwt subset | W1 proof gate | GitHub PR evidence | PR #75 / `f69f82fe58b47c821be73648cfbd34240dc3b629` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | Proof gate merged | W1 closure not claimed. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md` | auth; security-privacy; deployment-cwt subset | Deployed proof checklist | GitHub PR evidence | PR #76 / pending merge | Pending PR checks | BC-ALP-CONSOLIDATED-001 | Filed for review | Deployed proof still pending reviewer confirmation. |
 
 ---
 
@@ -34,5 +35,6 @@ FUNCTIONAL_PASS: NOT CLAIMED.
 CWT_PASS: NOT CLAIMED.
 Deployment acceptance: NOT CLAIMED.
 Production readiness: NOT CLAIMED.
-W1 closure: NOT CLAIMED until proof is accepted.
+W1 closure: NOT CLAIMED.
+W2 start: NOT CLAIMED.
 ```

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -3,11 +3,11 @@
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
 **Last Updated**: 2026-06-26  
-**Updated By**: W1 proof / closure gate filing  
-> **Classification**: ACTIVE - W1 PROOF / CLOSURE GATE FILED FOR REVIEW  
+**Updated By**: W1 deployed proof record filing  
+> **Classification**: ACTIVE - W1 DEPLOYED PROOF FILED FOR REVIEW  
 > **Repository**: APGI-cmy/Training  
 > **Current Workstream**: W1 Auth + Profile + Files proof and closure  
-> **Next Required Action**: Complete W1 proof before W1 closure or W2 start
+> **Next Required Action**: Attach reviewer-confirmed deployed proof before W1 closure or W2 start
 
 ---
 
@@ -19,7 +19,8 @@
 | W1 Entry Authorization | Authorized | PR #72 |
 | W1 Schema / Security | Merged | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` |
 | W1 App/Auth/Profile/Files | Merged | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` |
-| W1 Proof / Closure Gate | Filed for review | PR #75 pending |
+| W1 Proof Gate | Merged | PR #75 / `f69f82fe58b47c821be73648cfbd34240dc3b629` |
+| W1 Deployed Proof Record | Filed for review | PR #76 pending |
 
 W1 closure is not claimed.
 
@@ -29,12 +30,12 @@ W1 closure is not claimed.
 
 | Proof Item | Status | Required Evidence |
 |---|---|---|
-| Login proof | Pending | Deployed `/alp-sign-in` test |
-| Protected-route proof | Pending | Anonymous route handling test |
-| Role-boundary proof | Pending | Learner/admin route separation test |
-| Profile save proof | Pending | `/profile` save persists to `profiles` |
-| Private file upload proof | Pending | Upload record and metadata record |
-| Cross-learner RLS proof | Pending | Cross-user separation test |
+| Login proof | Pending reviewer confirmation | Deployed `/alp-sign-in` test |
+| Protected-route proof | Pending reviewer confirmation | Anonymous route handling test |
+| Role-boundary proof | Pending reviewer confirmation | Learner/admin route separation test |
+| Profile save proof | Pending reviewer confirmation | `/profile` save persists to `profiles` |
+| Private file upload proof | Pending reviewer confirmation | Upload record and metadata record |
+| Cross-learner RLS proof | Pending reviewer confirmation | Cross-user separation test |
 
 ---
 
@@ -43,7 +44,7 @@ W1 closure is not claimed.
 | Wave | Planned Scope | Status | Evidence Link(s) | Merge / PR Status | Check Status | Blocker / Risk |
 |---|---|---|---|---|---|---|
 | W0 | Foundation / Scaffold | CLOSED FOR SCAFFOLD SCOPE | W0 evidence files | PR #71 and PR #72 merged | Checks accepted before merge | Full app delivery not claimed |
-| W1 | Auth + Profile + Files | PROOF / CLOSURE GATE FILED | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | PR #73 and PR #74 merged; PR #75 pending | PR #75 checks pending review | Proof required before closure |
+| W1 | Auth + Profile + Files | DEPLOYED PROOF FILED FOR REVIEW | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md` | PR #73, #74, #75 merged; PR #76 pending | PR #76 checks pending | Reviewer proof required before closure |
 | W2 | Dashboard + Course Shell + Unit Viewer | WAITING FOR W1 | Pending W2 evidence | No W2 PR yet | No checks run | Requires W1 closure |
 | W3 | Progress + Completion | WAITING | Pending W3 evidence | No W3 PR yet | No checks run | Requires W2 closure |
 | W4 | Enrolment + Payments | WAITING | Pending W4 evidence | No W4 PR yet | No checks run | Requires W1/W2 closure |
@@ -63,7 +64,7 @@ W1 closure is not claimed.
 | ALP-CTRL-004 | CODE_PASS not claimed | Open | Claim only after code evidence exists. |
 | ALP-CTRL-005 | FUNCTIONAL_PASS not claimed | Open | Claim only after functional evidence exists. |
 | ALP-CTRL-006 | CWT_PASS not claimed | Open | Claim only after deployment/CWT evidence exists. |
-| ALP-CTRL-007 | W1 proof not accepted | Open | Complete the W1 proof set. |
+| ALP-CTRL-007 | W1 proof not accepted | Open | Attach or confirm the W1 deployed proof set. |
 | ALP-CTRL-008 | W2 waits for W1 | Open | Start W2 only after W1 proof is accepted and W1 is closed. |
 
 ---
@@ -71,7 +72,7 @@ W1 closure is not claimed.
 ## Immediate Next Action
 
 ```text
-Complete W1 proof and attach or confirm evidence before claiming W1 closure.
+Attach reviewer-confirmed W1 deployed proof before claiming W1 closure.
 ```
 
 ---
@@ -79,7 +80,7 @@ Complete W1 proof and attach or confirm evidence before claiming W1 closure.
 ## Build Authorization Posture
 
 ```text
-W1 Proof / Closure Gate: FILED FOR REVIEW
+W1 Deployed Proof Record: FILED FOR REVIEW
 W1 Closure: NOT CLAIMED
 W2 Start: WAITING FOR W1 CLOSURE
 Full App Delivery: NOT CLAIMED
@@ -96,4 +97,5 @@ Production readiness: NOT CLAIMED
 
 | Version | Date | Change Description | Changed By | Approval |
 |---|---|---|---|---|
-| 1.5 | 2026-06-26 | Filed W1 proof/closure gate, restored check-status tracking, and kept W2 waiting for W1 proof. | AI-assisted draft | Filed for review |
+| 1.5 | 2026-06-26 | Filed W1 proof/closure gate and kept W2 waiting for W1 proof. | AI-assisted draft | Merged by PR #75 |
+| 1.6 | 2026-06-26 | Filed W1 deployed proof record with proof pending reviewer confirmation. | AI-assisted draft | Filed for review |


### PR DESCRIPTION
## Summary

Records the W1 deployed-proof status after PR #75 merged.

This PR does not close W1. It files the deployed-proof checklist and keeps W2 waiting until reviewer-confirmed proof is attached or accepted.

## Updates

- Adds `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md`
- Updates `modules/ALP/11-build/evidence/index.md`
- Updates `modules/ALP/BUILD_PROGRESS_TRACKER.md`

## Current proof status

The following remain pending reviewer confirmation:

- login at `/alp-sign-in`
- anonymous protected-route handling
- learner/admin route separation
- profile save
- private file upload and metadata record
- cross-user RLS separation

## Explicit non-claims

No W1 closure, W2 start, full app delivery, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness is claimed.