### PR TITLE
Close ALP W1 and authorize W2 entry

### DIFF
--- a/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md
+++ b/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md
@@ -45,7 +45,7 @@
 ## Closure Decision
 
 ```text
-W1 Auth + Profile + Files: CLOSED FOR W1 SCOPE.
+W1 Auth + Profile + Files: PROPOSED CLOSED FOR W1 SCOPE (effective upon PR #77 merge).
 ```
 
 W1 is closed only for the approved W1 scope: auth route, protected profile route, profile save, private file upload, storage metadata, protected-route behavior, and practical cross-user separation.

--- a/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md
+++ b/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md
@@ -55,7 +55,7 @@ W1 is closed only for the approved W1 scope: auth route, protected profile route
 ## W2 Entry Authorization
 
 ```text
-W2 Dashboard + Course Shell + Unit Viewer: AUTHORIZED FOR ENTRY.
+W2 Dashboard + Course Shell + Unit Viewer: AUTHORIZED FOR ENTRY (effective after PR #77 merge).
 ```
 
 W2 may now start as the next implementation wave. This artifact authorizes W2 entry only. It does not implement W2.

--- a/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md
+++ b/modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md
@@ -1,0 +1,85 @@
+# W1 Closure / W2 Entry Evidence
+
+## Status
+
+| Field | Value |
+|---|---|
+| Module | ALP - APGI Learning Portal |
+| Wave | W1 - Auth + Profile + Files |
+| Evidence Type | Closure decision and W2 entry authorization |
+| Date | 2026-06-26 |
+| Status | Filed for review |
+| Branch | alp-w1-closure-w2-entry |
+| Planned PR | #77 |
+
+---
+
+## Merged Inputs
+
+| Input | PR | Merge Commit | Status |
+|---|---:|---|---|
+| W1 schema/security | #73 | `f87cd253b266fc6dc7725693dcfdf55762afe472` | Merged |
+| W1 app/auth/profile/files | #74 | `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` | Merged |
+| W1 proof gate | #75 | `f69f82fe58b47c821be73648cfbd34240dc3b629` | Merged |
+| W1 deployed proof | #76 | `0c08771d71a9a59028c50666238f5db8877ada81` | Merged |
+
+---
+
+## W1 Proof Accepted for Closure
+
+| Proof Item | Closure Status |
+|---|---|
+| Public course route | Accepted |
+| Login at `/alp-sign-in` | Accepted |
+| Supabase auth user exists | Accepted |
+| Anonymous `/profile` redirect to sign-in | Accepted |
+| Authenticated `/profile` route | Accepted |
+| Profile save to `profiles` | Accepted |
+| Private file upload | Accepted |
+| Uploaded file list renders | Accepted |
+| Cross-user RLS separation | Accepted |
+| Learner/admin route separation | Accepted with limitation: `/admin` did not expose admin content; full admin-console proof deferred to future admin wave |
+
+---
+
+## Closure Decision
+
+```text
+W1 Auth + Profile + Files: CLOSED FOR W1 SCOPE.
+```
+
+W1 is closed only for the approved W1 scope: auth route, protected profile route, profile save, private file upload, storage metadata, protected-route behavior, and practical cross-user separation.
+
+---
+
+## W2 Entry Authorization
+
+```text
+W2 Dashboard + Course Shell + Unit Viewer: AUTHORIZED FOR ENTRY.
+```
+
+W2 may now start as the next implementation wave. This artifact authorizes W2 entry only. It does not implement W2.
+
+---
+
+## W1 Known Limitations / Follow-Up Controls
+
+| Item | Status |
+|---|---|
+| `/admin` route | Does not expose admin content, but full admin console proof is deferred. |
+| `/login` alias | Not present; W1 uses `/alp-sign-in`. |
+| Logout UI | Not exposed in W1. |
+| Full app workflows | Still incomplete and reserved for later waves. |
+
+---
+
+## Non-Claims
+
+```text
+Full app delivery: Not claimed.
+CODE_PASS: Not claimed.
+FUNCTIONAL_PASS: Not claimed.
+CWT_PASS: Not claimed.
+Deployment acceptance: Not claimed.
+Production readiness: Not claimed.
+```

--- a/modules/ALP/11-build/evidence/index.md
+++ b/modules/ALP/11-build/evidence/index.md
@@ -15,14 +15,15 @@
 
 ## Evidence Roll-Up
 
-| Wave | Evidence File | QA Marker(s) | Golden / Negative Path | Environment | PR / Commit | Check Status | Reviewer / Owner | Closure Status | Notes |
-|---|---|---|---|---|---|---|---|---|---|
-| W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | governance-artifacts; architecture-inventory; deployment-cwt subset | Golden scaffold/governance path | GitHub / Vercel preview | PR #71 / `48ce32a1974b14487864713af1287ab0379cf4d8` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | Closed for scaffold scope | No full app delivery claim. |
-| W0 | `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | GOV-ALP-072 | W1 entry authorization | GitHub PR evidence | PR #72 / `60663768ca2a960fbfd4d9a50bf88c71a4479e25` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | W1 entry authorized | No W1 implementation delivered by this artifact. |
-| W1 | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | auth; security-privacy; architecture-inventory | Schema/security path | GitHub PR evidence | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | Schema/security slice merged | W1 closure not claimed. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-074-decision-app-auth-profile-files-pass.md` | auth; security-privacy; architecture-inventory | App/auth/profile/files path | GitHub PR evidence | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | App/auth/profile/files slice merged | Browser proof and W1 closure remain pending. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | auth; security-privacy; deployment-cwt subset | W1 proof gate | GitHub PR evidence | PR #75 / `f69f82fe58b47c821be73648cfbd34240dc3b629` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | Proof gate merged | W1 closure not claimed. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md` | auth; security-privacy; deployment-cwt subset | Deployed proof checklist | GitHub PR evidence | PR #76 / pending merge | Pending PR checks | BC-ALP-CONSOLIDATED-001 | Filed for review | Deployed proof still pending reviewer confirmation. |
+| Wave | Evidence File | PR / Commit | Check Status | Closure Status | Notes |
+|---|---|---|---|---|---|
+| W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | PR #71 / `48ce32a1974b14487864713af1287ab0379cf4d8` | Vercel accepted before merge | Closed for scaffold scope | No full app delivery claim. |
+| W0 | `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | PR #72 / `60663768ca2a960fbfd4d9a50bf88c71a4479e25` | Vercel accepted before merge | W1 entry authorized | No W1 implementation delivered by this artifact. |
+| W1 | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` | Vercel accepted before merge | Schema/security slice merged | W1 closure included in PR #77. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-074-decision-app-auth-profile-files-pass.md` | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` | Vercel accepted before merge | App/auth/profile/files slice merged | W1 closure included in PR #77. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | PR #75 / `f69f82fe58b47c821be73648cfbd34240dc3b629` | Vercel accepted before merge | Proof gate merged | W1 closure included in PR #77. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md` | PR #76 / `0c08771d71a9a59028c50666238f5db8877ada81` | Vercel accepted before merge | Deployed proof accepted | Supports W1 closure. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md` | PR #77 / pending merge | Pending PR checks | Filed for review | Closes W1 for W1 scope and authorizes W2 entry if merged. |
 
 ---
 
@@ -35,6 +36,4 @@ FUNCTIONAL_PASS: NOT CLAIMED.
 CWT_PASS: NOT CLAIMED.
 Deployment acceptance: NOT CLAIMED.
 Production readiness: NOT CLAIMED.
-W1 closure: NOT CLAIMED.
-W2 start: NOT CLAIMED.
 ```

--- a/modules/ALP/11-build/evidence/index.md
+++ b/modules/ALP/11-build/evidence/index.md
@@ -19,9 +19,9 @@
 |---|---|---|---|---|---|
 | W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | PR #71 / `48ce32a1974b14487864713af1287ab0379cf4d8` | Vercel accepted before merge | Closed for scaffold scope | No full app delivery claim. |
 | W0 | `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | PR #72 / `60663768ca2a960fbfd4d9a50bf88c71a4479e25` | Vercel accepted before merge | W1 entry authorized | No W1 implementation delivered by this artifact. |
-| W1 | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` | Vercel accepted before merge | Schema/security slice merged | W1 closure included in PR #77. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-074-decision-app-auth-profile-files-pass.md` | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` | Vercel accepted before merge | App/auth/profile/files slice merged | W1 closure included in PR #77. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | PR #75 / `f69f82fe58b47c821be73648cfbd34240dc3b629` | Vercel accepted before merge | Proof gate merged | W1 closure included in PR #77. |
+| W1 | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` | Vercel accepted before merge | Schema/security slice merged | Supports W1 closure decision in PR #77. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-074-decision-app-auth-profile-files-pass.md` | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` | Vercel accepted before merge | App/auth/profile/files slice merged | Supports W1 closure decision in PR #77. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | PR #75 / `f69f82fe58b47c821be73648cfbd34240dc3b629` | Vercel accepted before merge | Proof gate merged | Supports W1 closure decision in PR #77. |
 | W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md` | PR #76 / `0c08771d71a9a59028c50666238f5db8877ada81` | Vercel accepted before merge | Deployed proof accepted | Supports W1 closure. |
 | W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md` | PR #77 / pending merge | Pending PR checks | Filed for review | Closes W1 for W1 scope and authorizes W2 entry if merged. |
 

--- a/modules/ALP/11-build/evidence/index.md
+++ b/modules/ALP/11-build/evidence/index.md
@@ -7,7 +7,7 @@
 | Module | ALP - APGI Learning Portal |
 | Artifact | Build Evidence Index |
 | Status | Filed for review |
-| Date | 2026-06-26 |
+| Date | 2026-06-29 |
 | Repository | APGI-cmy/Training |
 | Canonical Path | `modules/ALP/11-build/evidence/index.md` |
 
@@ -15,15 +15,15 @@
 
 ## Evidence Roll-Up
 
-| Wave | Evidence File | PR / Commit | Check Status | Closure Status | Notes |
-|---|---|---|---|---|---|
-| W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | PR #71 / `48ce32a1974b14487864713af1287ab0379cf4d8` | Vercel accepted before merge | Closed for scaffold scope | No full app delivery claim. |
-| W0 | `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | PR #72 / `60663768ca2a960fbfd4d9a50bf88c71a4479e25` | Vercel accepted before merge | W1 entry authorized | No W1 implementation delivered by this artifact. |
-| W1 | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` | Vercel accepted before merge | Schema/security slice merged | Supports W1 closure decision in PR #77. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-074-decision-app-auth-profile-files-pass.md` | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` | Vercel accepted before merge | App/auth/profile/files slice merged | Supports W1 closure decision in PR #77. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | PR #75 / `f69f82fe58b47c821be73648cfbd34240dc3b629` | Vercel accepted before merge | Proof gate merged | Supports W1 closure decision in PR #77. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md` | PR #76 / `0c08771d71a9a59028c50666238f5db8877ada81` | Vercel accepted before merge | Deployed proof accepted | Supports W1 closure. |
-| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md` | PR #77 / pending merge | Pending PR checks | Filed for review | Closes W1 for W1 scope and authorizes W2 entry if merged. |
+| Wave | Evidence File | QA Marker(s) | Golden / Negative Path | Environment | PR / Commit | Check Status | Reviewer / Owner | Closure Status | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | governance-artifacts; architecture-inventory; deployment-cwt subset | Golden scaffold/governance path | GitHub / Vercel preview | PR #71 / `48ce32a1974b14487864713af1287ab0379cf4d8` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | Closed for scaffold scope | No full app delivery claim. |
+| W0 | `modules/ALP/11-build/evidence/20260624-W0-GOV-ALP-072-decision-w0-closure-w1-entry.md` | GOV-ALP-072 | W1 entry authorization | GitHub PR evidence | PR #72 / `60663768ca2a960fbfd4d9a50bf88c71a4479e25` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | W1 entry authorized | No W1 implementation delivered by this artifact. |
+| W1 | `modules/ALP/11-build/evidence/20260625-W1-GOV-ALP-073-decision-schema-security-pass.md` | auth; security-privacy; architecture-inventory | Schema/security path | GitHub PR evidence | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | Schema/security slice merged | Supports W1 closure decision in PR #77. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-074-decision-app-auth-profile-files-pass.md` | auth; security-privacy; architecture-inventory | App/auth/profile/files path | GitHub PR evidence | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | App/auth/profile/files slice merged | Supports W1 closure decision in PR #77. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-075-decision-proof-closure-gate.md` | auth; security-privacy; deployment-cwt subset | W1 proof gate | GitHub PR evidence | PR #75 / `f69f82fe58b47c821be73648cfbd34240dc3b629` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | Proof gate merged | Supports W1 closure decision in PR #77. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md` | auth; security-privacy; deployment-cwt subset | Deployed proof checklist | GitHub PR evidence and reviewer screenshots | PR #76 / `0c08771d71a9a59028c50666238f5db8877ada81` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 / reviewer proof | Deployed proof accepted | Supports W1 closure. |
+| W1 | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md` | GOV-ALP-077; auth; security-privacy | W1 closure / W2 entry | GitHub PR evidence | PR #77 / pending merge | Pending PR checks | BC-ALP-CONSOLIDATED-001 | Filed for review | Closes W1 for W1 scope and authorizes W2 entry if merged. |
 
 ---
 
@@ -35,5 +35,6 @@ CODE_PASS: NOT CLAIMED.
 FUNCTIONAL_PASS: NOT CLAIMED.
 CWT_PASS: NOT CLAIMED.
 Deployment acceptance: NOT CLAIMED.
-Production readiness: NOT CLAIMED. W2 start: NOT CLAIMED (entry authorized after PR #77 merge).
+Production readiness: NOT CLAIMED.
+W2 start: NOT CLAIMED; W2 entry is authorized only after PR #77 merge.
 ```

--- a/modules/ALP/11-build/evidence/index.md
+++ b/modules/ALP/11-build/evidence/index.md
@@ -35,5 +35,5 @@ CODE_PASS: NOT CLAIMED.
 FUNCTIONAL_PASS: NOT CLAIMED.
 CWT_PASS: NOT CLAIMED.
 Deployment acceptance: NOT CLAIMED.
-Production readiness: NOT CLAIMED.
+Production readiness: NOT CLAIMED. W2 start: NOT CLAIMED (entry authorized after PR #77 merge).
 ```

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -3,11 +3,11 @@
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
 **Last Updated**: 2026-06-26  
-**Updated By**: W1 deployed proof record filing  
-> **Classification**: ACTIVE - W1 DEPLOYED PROOF FILED FOR REVIEW  
+**Updated By**: W1 closure / W2 entry filing  
+> **Classification**: ACTIVE - W1 CLOSURE FILED FOR REVIEW  
 > **Repository**: APGI-cmy/Training  
-> **Current Workstream**: W1 Auth + Profile + Files proof and closure  
-> **Next Required Action**: Attach reviewer-confirmed deployed proof before W1 closure or W2 start
+> **Current Workstream**: W1 closure and W2 entry authorization  
+> **Next Required Action**: Review and merge PR #77 before starting W2 implementation
 
 ---
 
@@ -20,22 +20,21 @@
 | W1 Schema / Security | Merged | PR #73 / `f87cd253b266fc6dc7725693dcfdf55762afe472` |
 | W1 App/Auth/Profile/Files | Merged | PR #74 / `d2ab509d64d78ec31f8c4652d3a94e63a6da1e8d` |
 | W1 Proof Gate | Merged | PR #75 / `f69f82fe58b47c821be73648cfbd34240dc3b629` |
-| W1 Deployed Proof Record | Filed for review | PR #76 pending |
-
-W1 closure is not claimed.
+| W1 Deployed Proof Record | Merged | PR #76 / `0c08771d71a9a59028c50666238f5db8877ada81` |
+| W1 Closure / W2 Entry | Filed for review | PR #77 pending |
 
 ---
 
-## W1 Proof Required
+## W1 Proof Accepted
 
-| Proof Item | Status | Required Evidence |
-|---|---|---|
-| Login proof | Pending reviewer confirmation | Deployed `/alp-sign-in` test |
-| Protected-route proof | Pending reviewer confirmation | Anonymous route handling test |
-| Role-boundary proof | Pending reviewer confirmation | Learner/admin route separation test |
-| Profile save proof | Pending reviewer confirmation | `/profile` save persists to `profiles` |
-| Private file upload proof | Pending reviewer confirmation | Upload record and metadata record |
-| Cross-learner RLS proof | Pending reviewer confirmation | Cross-user separation test |
+| Proof Item | Status |
+|---|---|
+| Login proof | Accepted |
+| Protected-route proof | Accepted |
+| Role-boundary proof | Accepted with admin-route limitation recorded |
+| Profile save proof | Accepted |
+| Private file upload proof | Accepted |
+| Cross-learner RLS proof | Accepted |
 
 ---
 
@@ -44,8 +43,8 @@ W1 closure is not claimed.
 | Wave | Planned Scope | Status | Evidence Link(s) | Merge / PR Status | Check Status | Blocker / Risk |
 |---|---|---|---|---|---|---|
 | W0 | Foundation / Scaffold | CLOSED FOR SCAFFOLD SCOPE | W0 evidence files | PR #71 and PR #72 merged | Checks accepted before merge | Full app delivery not claimed |
-| W1 | Auth + Profile + Files | DEPLOYED PROOF FILED FOR REVIEW | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-076-decision-deployed-proof-closure.md` | PR #73, #74, #75 merged; PR #76 pending | PR #76 checks pending | Reviewer proof required before closure |
-| W2 | Dashboard + Course Shell + Unit Viewer | WAITING FOR W1 | Pending W2 evidence | No W2 PR yet | No checks run | Requires W1 closure |
+| W1 | Auth + Profile + Files | CLOSURE FILED FOR REVIEW | `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md` | PR #73-#76 merged; PR #77 pending | PR #77 checks pending | Merge PR #77 to close W1 |
+| W2 | Dashboard + Course Shell + Unit Viewer | AUTHORIZED AFTER PR #77 MERGE | Pending W2 evidence | No W2 PR yet | No checks run | Start only after PR #77 merge |
 | W3 | Progress + Completion | WAITING | Pending W3 evidence | No W3 PR yet | No checks run | Requires W2 closure |
 | W4 | Enrolment + Payments | WAITING | Pending W4 evidence | No W4 PR yet | No checks run | Requires W1/W2 closure |
 | W5 | Assessment Submission | WAITING | Pending W5 evidence | No W5 PR yet | No checks run | Requires W1/W3/W4 closure |
@@ -60,19 +59,19 @@ W1 closure is not claimed.
 
 | Control ID | Control | Current Status | Required Next Action |
 |---|---|---|---|
-| ALP-CTRL-003 | Full app workflows not complete | Open | Complete W1-W9 implementation and evidence. |
+| ALP-CTRL-003 | Full app workflows not complete | Open | Complete W2-W9 implementation and evidence. |
 | ALP-CTRL-004 | CODE_PASS not claimed | Open | Claim only after code evidence exists. |
 | ALP-CTRL-005 | FUNCTIONAL_PASS not claimed | Open | Claim only after functional evidence exists. |
 | ALP-CTRL-006 | CWT_PASS not claimed | Open | Claim only after deployment/CWT evidence exists. |
-| ALP-CTRL-007 | W1 proof not accepted | Open | Attach or confirm the W1 deployed proof set. |
-| ALP-CTRL-008 | W2 waits for W1 | Open | Start W2 only after W1 proof is accepted and W1 is closed. |
+| ALP-CTRL-007 | W1 proof accepted | Closed for W1 scope | Review and merge PR #77. |
+| ALP-CTRL-008 | W2 waits for W1 closure | Pending closure merge | Start W2 only after PR #77 merge. |
 
 ---
 
 ## Immediate Next Action
 
 ```text
-Attach reviewer-confirmed W1 deployed proof before claiming W1 closure.
+Review and merge PR #77. After merge, W2 may start.
 ```
 
 ---
@@ -80,9 +79,8 @@ Attach reviewer-confirmed W1 deployed proof before claiming W1 closure.
 ## Build Authorization Posture
 
 ```text
-W1 Deployed Proof Record: FILED FOR REVIEW
-W1 Closure: NOT CLAIMED
-W2 Start: WAITING FOR W1 CLOSURE
+W1 Closure: FILED FOR REVIEW
+W2 Start: AUTHORIZED AFTER PR #77 MERGE
 Full App Delivery: NOT CLAIMED
 CODE_PASS: NOT CLAIMED
 FUNCTIONAL_PASS: NOT CLAIMED
@@ -98,4 +96,5 @@ Production readiness: NOT CLAIMED
 | Version | Date | Change Description | Changed By | Approval |
 |---|---|---|---|---|
 | 1.5 | 2026-06-26 | Filed W1 proof/closure gate and kept W2 waiting for W1 proof. | AI-assisted draft | Merged by PR #75 |
-| 1.6 | 2026-06-26 | Filed W1 deployed proof record with proof pending reviewer confirmation. | AI-assisted draft | Filed for review |
+| 1.6 | 2026-06-26 | Filed W1 deployed proof record with proof pending reviewer confirmation. | AI-assisted draft | Merged by PR #76 |
+| 1.7 | 2026-06-26 | Filed W1 closure and W2 entry authorization. | AI-assisted draft | Filed for review |

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -2,7 +2,7 @@
 
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
-**Last Updated**: 2026-06-26  
+**Last Updated**: 2026-06-29  
 **Updated By**: W1 closure / W2 entry filing  
 > **Classification**: ACTIVE - W1 CLOSURE FILED FOR REVIEW  
 > **Repository**: APGI-cmy/Training  
@@ -97,4 +97,4 @@ Production readiness: NOT CLAIMED
 |---|---|---|---|---|
 | 1.5 | 2026-06-26 | Filed W1 proof/closure gate and kept W2 waiting for W1 proof. | AI-assisted draft | Merged by PR #75 |
 | 1.6 | 2026-06-26 | Filed W1 deployed proof record with proof pending reviewer confirmation. | AI-assisted draft | Merged by PR #76 |
-| 1.7 | 2026-06-26 | Filed W1 closure and W2 entry authorization. | AI-assisted draft | Filed for review |
+| 1.7 | 2026-06-29 | Filed W1 closure and W2 entry authorization. | AI-assisted draft | Filed for review |


### PR DESCRIPTION
## Summary

Files the actual W1 closure decision after PR #76 merged the deployed proof record.

This PR closes W1 for its approved Auth + Profile + Files scope and authorizes W2 entry after merge.

## Updates

- Adds `modules/ALP/11-build/evidence/20260626-W1-GOV-ALP-077-decision-w1-closure-w2-entry.md`
- Updates `modules/ALP/11-build/evidence/index.md`
- Updates `modules/ALP/BUILD_PROGRESS_TRACKER.md`

## W1 closure basis

W1 proof accepted for closure includes:

- public course route
- `/alp-sign-in` login
- Supabase auth user
- anonymous `/profile` redirect to sign-in
- authenticated `/profile`
- profile save to `profiles`
- private file upload
- uploaded file list rendering
- practical cross-user separation
- limited role-boundary proof where `/admin` did not expose admin content

## W2 authorization

After this PR is reviewed and merged, W2 Dashboard + Course Shell + Unit Viewer may start as the next implementation wave.

## Explicit non-claims

No full app delivery, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, deployment acceptance, or production readiness is claimed.