### PR TITLE
Normalize GOV-ALP-083 evidence status header after W3 closure

### DIFF
--- a/modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-082-decision-deployed-proof-closure.md
+++ b/modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-082-decision-deployed-proof-closure.md
@@ -8,11 +8,13 @@
 | Wave | W3 - Progress + Completion |
 | Evidence Type | Deployed UI proof record |
 | Date | 2026-07-01 |
-| Status | Filed for review |
-| Branch | alp-w3-deployed-proof-closure |
-| Planned PR | #82 |
-| Prior PRs | #80 and #81 |
-| Deployment URL | `https://training-platform-kappa.vercel.app` |
+| Status | Merged as deployed UI proof only |
+| Branch | `alp-w3-deployed-proof-closure` |
+| Closure PR | PR #82 - merged 2026-07-02 |
+| Merge Commit | `91788475ec52905aed0ee1d0f8d75681c8439310` |
+| Prior PRs | PR #80 and PR #81 |
+| Closure Posture | PR #82 did not close W3; W3 closure required later database-backed proof in PR #83. |
+| Carry Forward | ALP-CTRL-010 and ALP-CTRL-011 carried forward from PR #82. |
 
 ---
 
@@ -40,38 +42,42 @@ Reviewer then repeated deployed UI proof successfully.
 
 ---
 
-## Open Controls
+## Open Controls at PR #82 Merge
 
-| Control ID | Control | Status | Required Action | Owner Wave |
+| Control ID | Control | Status at PR #82 Merge | Required Action | Owner Wave |
 |---|---|---|---|---|
 | ALP-CTRL-010 | Legacy iSpring embedded video objects do not consistently play. | Open | Inspect exported iSpring asset references, video file availability, MIME type, and browser console or network errors. | W3 content-hardening or later content QA |
-| ALP-CTRL-011 | Live Supabase progress tables must be applied or verified before database-backed progress becomes the long-term source of truth. | Blocking W3 closure | Apply or verify W3 progress migration tables: `progress_events`, `learner_progress`, and `completion_states`; then capture database-backed progress proof. | W3 follow-up before W4 entry |
+| ALP-CTRL-011 | Live Supabase progress tables must be applied or verified before database-backed progress becomes the long-term source of truth. | Carried forward from PR #82; later closed by PR #83 | Apply or verify W3 progress migration tables and capture database-backed progress proof. | W3 follow-up before W4 entry |
 
 ---
 
 ## Decision
 
-This PR records W3 deployed UI proof only.
+PR #82 records W3 deployed UI proof only.
 
-W3 does not close in this PR because ALP-CTRL-011 remains open. W4 must not start until Supabase database-backed progress proof is captured.
+W3 did not close in PR #82 because ALP-CTRL-011 remained open at the time of merge. W4 was not authorized by PR #82.
+
+ALP-CTRL-011 was subsequently closed by PR #83 after live Supabase database-backed progress proof was captured.
 
 ---
 
 ## Non-Claims
 
-W3 closure: NOT CLAIMED.  
-W4 entry authorization: NOT CLAIMED.  
+W3 closure: NOT CLAIMED BY PR #82.  
+W4 entry authorization: NOT CLAIMED BY PR #82.  
 Full app delivery: NOT CLAIMED.  
 CODE_PASS: NOT CLAIMED.  
 FUNCTIONAL_PASS: NOT CLAIMED.  
 CWT_PASS: NOT CLAIMED.  
 Final content quality acceptance: NOT CLAIMED.  
-Long-term database-backed progress source of truth: NOT CLAIMED until ALP-CTRL-011 is closed.  
+Long-term database-backed progress source of truth: NOT CLAIMED BY PR #82; later claimed for W3 progress scope by PR #83.  
 Deployment acceptance for all waves: NOT CLAIMED.  
 Production readiness: NOT CLAIMED.
 
 ---
 
-## Next Required Action
+## Next Required Action at PR #82 Merge
 
 Apply or verify the live Supabase progress tables and capture database-backed progress proof before filing W3 closure or authorizing W4.
+
+This follow-up action was completed by PR #83 for ALP-CTRL-011.

--- a/modules/ALP/11-build/evidence/20260702-W3-GOV-ALP-083-decision-db-progress-closure.md
+++ b/modules/ALP/11-build/evidence/20260702-W3-GOV-ALP-083-decision-db-progress-closure.md
@@ -1,9 +1,26 @@
 # GOV-ALP-083 - W3 Database Progress Closure Evidence
 
-Date: 2026-07-02
-Module: ALP
-Wave: W3 Progress and Completion
-Control: ALP-CTRL-011
+## Status Header
+
+| Field | Value |
+|---|---|
+| Module | ALP - APGI Learning Portal |
+| Artifact | GOV-ALP-083 - W3 Database Progress Closure Evidence |
+| Wave | W3 Progress and Completion |
+| Control | ALP-CTRL-011 |
+| Status | Closed by PR #83 merge |
+| Date | 2026-07-02 |
+| Repository | APGI-cmy/Training |
+| Canonical Path | `modules/ALP/11-build/evidence/20260702-W3-GOV-ALP-083-decision-db-progress-closure.md` |
+| Branch | `alp-w3-db-proof-closure` |
+| Closure PR | PR #83 - merged 2026-07-02 |
+| Merge Commit | `55c686aeda1dc293d6ad6de72526f86e2cb488c9` |
+| Reviewer / Owner | BC-ALP-CONSOLIDATED-001 |
+| Closure Posture | W3 database-backed progress proof accepted for ALP-CTRL-011 closure. |
+| Carry Forward | ALP-CTRL-010 remains open. |
+| Non-Claims | No full app delivery, CODE_PASS, FUNCTIONAL_PASS, CWT_PASS, or production readiness claimed. |
+
+---
 
 ## Summary
 
@@ -11,30 +28,38 @@ The live Supabase W3 progress migration was applied successfully.
 
 The following tables were verified in the live project:
 
-- public.progress_events
-- public.learner_progress
-- public.completion_states
+- `public.progress_events`
+- `public.learner_progress`
+- `public.completion_states`
 
 RLS was verified as enabled on all three tables.
 
-Database-backed progress proof was captured for course vpshr-level-0 and unit introduction.
+Database-backed progress proof was captured for course `vpshr-level-0` and unit `introduction`.
+
+---
 
 ## Proof
 
 Rows were verified in all three W3 progress tables:
 
-- progress_events: 1 unit_completed row
-- learner_progress: 1 completed row
-- completion_states: 1 progress state row showing 1 of 13 units complete, 7.69 percent
+| Table | Proof Row |
+|---|---|
+| `progress_events` | 1 `unit_completed` row |
+| `learner_progress` | 1 `completed` row |
+| `completion_states` | 1 progress state row showing 1 of 13 units complete, 7.69 percent |
 
-Proof timestamp: 2026-07-02 08:12:24 UTC
+Proof timestamp: `2026-07-02 08:12:24 UTC`
 
-## Closure posture
+---
 
-This evidence supports closing ALP-CTRL-011 after this PR is merged.
+## Closure Posture
 
-PR #82 remains the deployed UI proof record. This evidence is database-backed progress proof. The available Vercel connector did not expose the training-platform-kappa project during filing, so no fresh browser-click proof is claimed here.
+PR #83 has been merged. This evidence closes ALP-CTRL-011 for the W3 database-backed progress proof requirement.
 
-W4 remains unauthorized until this PR is merged.
+PR #82 remains the deployed UI proof record. This evidence is database-backed progress proof. No fresh browser-click proof is claimed here.
+
+W3 Progress and Completion may be treated as closed for the approved W3 scope after PR #83 merge.
+
+W4 may be authorized for entry after PR #83 merge, subject to normal W4 entry governance.
 
 ALP-CTRL-010 remains open and carried forward.

--- a/modules/ALP/11-build/evidence/index.md
+++ b/modules/ALP/11-build/evidence/index.md
@@ -6,7 +6,7 @@
 |---|---|
 | Module | ALP - APGI Learning Portal |
 | Artifact | Build Evidence Index |
-| Status | Filed for review |
+| Status | Updated after PR #83 merge |
 | Date | 2026-07-02 |
 | Repository | APGI-cmy/Training |
 | Canonical Path | `modules/ALP/11-build/evidence/index.md` |
@@ -22,20 +22,19 @@
 | W2 | W2 evidence files | GOV-ALP-078; GOV-ALP-079 | Dashboard / course shell / unit viewer path | GitHub / Vercel / reviewer screenshots | PR #78-#79 | Accepted before merge | BC-ALP-CONSOLIDATED-001 / reviewer proof | Closed for W2 scope | Carries ALP-CTRL-010 forward. |
 | W3 | `modules/ALP/11-build/evidence/20260630-W3-GOV-ALP-080-decision-progress-completion-entry.md` | GOV-ALP-080; progress-completion | W3 progress / completion entry path | GitHub PR evidence | PR #80 / `529c5cac1c312fb117e311a9d1b03ca7540161bf` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 | Merged | W3 implementation slice only. |
 | W3 | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-081-decision-progress-proof-fix.md` | GOV-ALP-081; progress-proof | W3 progress proof fix path | GitHub PR evidence / reviewer proof | PR #81 / `27f96a9efb9294158ed16b47524ceeeabbb93892` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 / reviewer proof | Merged | Visible progress recording fixed. |
-| W3 | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-082-decision-deployed-proof-closure.md` | GOV-ALP-082; deployed-ui-proof | W3 deployed UI proof path | Deployed app / reviewer screenshot | PR #82 / pending merge | Pending PR checks | BC-ALP-CONSOLIDATED-001 / reviewer proof | Filed for review; deployed UI proof only | PR #82 does not close W3 or authorize W4; ALP-CTRL-011 still required database proof. |
-| W3 | `modules/ALP/11-build/evidence/20260702-W3-GOV-ALP-083-decision-db-progress-closure.md` | GOV-ALP-083; db-progress-proof; ALP-CTRL-011 | W3 database-backed progress closure path | Live Supabase / GitHub PR evidence | PR #83 / pending merge | Pending PR checks | BC-ALP-CONSOLIDATED-001 | Filed for review; W3 closable after merge | Live migration verified for `public.progress_events`, `public.learner_progress`, and `public.completion_states`; `vpshr-level-0` / `introduction` proof rows captured as `unit_completed`, `completed`, and `1 of 13`, `7.69%`. |
+| W3 | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-082-decision-deployed-proof-closure.md` | GOV-ALP-082; deployed-ui-proof | W3 deployed UI proof path | Deployed app / reviewer screenshot | PR #82 / merged | Merged | BC-ALP-CONSOLIDATED-001 / reviewer proof | Deployed UI proof only | PR #82 did not close W3 or authorize W4; ALP-CTRL-011 still required database proof. |
+| W3 | `modules/ALP/11-build/evidence/20260702-W3-GOV-ALP-083-decision-db-progress-closure.md` | GOV-ALP-083; db-progress-proof; ALP-CTRL-011 | W3 database-backed progress closure path | Live Supabase / GitHub PR evidence | PR #83 / `55c686aeda1dc293d6ad6de72526f86e2cb488c9` | Merged | BC-ALP-CONSOLIDATED-001 | Closed for approved W3 scope | Live migration verified for `public.progress_events`, `public.learner_progress`, and `public.completion_states`; `vpshr-level-0` / `introduction` proof rows captured as `unit_completed`, `completed`, and `1 of 13`, `7.69%`. |
 
 ---
 
 ## Current Non-Claims
 
 Full app delivery: NOT CLAIMED.  
-W3 closure: NOT CLAIMED until PR #83 is merged.  
-W4 entry authorization: NOT CLAIMED until PR #83 is merged.  
 CODE_PASS: NOT CLAIMED.  
 FUNCTIONAL_PASS: NOT CLAIMED.  
 CWT_PASS: NOT CLAIMED.  
 Final content quality acceptance: NOT CLAIMED.  
-Long-term database-backed progress source of truth: NOT CLAIMED until ALP-CTRL-011 is closed.  
 Deployment acceptance: NOT CLAIMED.  
-Production readiness: NOT CLAIMED.
+Production readiness: NOT CLAIMED.  
+ALP-CTRL-010: OPEN and carried forward.  
+W4: AUTHORIZED FOR ENTRY after PR #83 merge, but W4 implementation/closure is NOT CLAIMED.

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -3,11 +3,11 @@
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
 **Last Updated**: 2026-07-02  
-**Updated By**: W3 database-backed progress proof filing  
-> **Classification**: ACTIVE - W3 DATABASE-BACKED PROOF FILED; MERGE REQUIRED FOR CLOSURE  
+**Updated By**: GOV-ALP-083 post-merge evidence normalization  
+> **Classification**: ACTIVE - W3 DATABASE-BACKED PROOF CLOSED; W4 ENTRY AUTHORIZED  
 > **Repository**: APGI-cmy/Training  
-> **Current Workstream**: W3 governance closure via PR #83  
-> **Next Required Action**: Merge PR #83 to close ALP-CTRL-011 and keep W4 blocked until that merge
+> **Current Workstream**: W4 Enrolment + Payments entry governance  
+> **Next Required Action**: Open W4 entry / implementation PR while carrying ALP-CTRL-010 and non-claims forward
 
 ---
 
@@ -18,8 +18,8 @@
 | W0 Foundation / Scaffold | Closed for scaffold scope | PR #71 |
 | W1 Closure / W2 Entry | Closed for W1 scope | PR #77 / `f492c8efd8c83cbca49481191315ac2869c62c3b` |
 | W2 Dashboard / Course Shell / Unit Viewer | Closed for W2 scope | PR #79 / `1b2ae564437a90349ccca95138ac430bf680089b` |
-| W3 Progress + Completion | Database-backed proof filed; closable after PR #83 merge | PR #80 and PR #81 merged; PR #82 deployed UI proof only; PR #83 pending |
-| W4 Enrolment + Payments | Waiting / not authorized | Requires PR #83 merge for W3 closure |
+| W3 Progress + Completion | Closed for approved W3 database-backed progress scope | PR #80 and PR #81 merged; PR #82 deployed UI proof only; PR #83 merged |
+| W4 Enrolment + Payments | Waiting / authorized for entry | Authorized after PR #83 merge; requires W4 entry PR before implementation closure |
 
 ---
 
@@ -33,11 +33,11 @@
 | Completion confirmation message | Accepted |
 | Course shell progress update | Accepted |
 | Dashboard progress update | Accepted |
-| Supabase database-progress source of truth | Database proof filed in PR #83; closure only after merge |
+| Supabase database-progress source of truth | Database proof closed by PR #83 merge |
 
 ---
 
-## W3 Database-Backed Proof Filed
+## W3 Database-Backed Proof Closed
 
 | Proof Item | Status |
 |---|---|
@@ -46,7 +46,7 @@
 | `public.progress_events` | Verified with `vpshr-level-0` / `introduction` proof row `unit_completed`. |
 | `public.learner_progress` | Verified with `vpshr-level-0` / `introduction` proof row `completed`. |
 | `public.completion_states` | Verified with `vpshr-level-0` / `introduction` proof state `1 of 13`, `7.69%`. |
-| ALP-CTRL-011 posture | Closable by PR #83 after merge; not closed while this PR is pending. |
+| ALP-CTRL-011 posture | Closed by PR #83 merge. |
 
 ---
 
@@ -57,8 +57,8 @@
 | W0 | Foundation / Scaffold | CLOSED FOR SCAFFOLD SCOPE | W0 evidence files | PR #71 and PR #72 merged | Checks accepted before merge | Full app delivery not claimed |
 | W1 | Auth + Profile + Files | CLOSED FOR W1 SCOPE | W1 evidence files | PR #73-#77 merged | Checks accepted before merge | Admin console proof deferred |
 | W2 | Dashboard + Course Shell + Unit Viewer | CLOSED FOR W2 SCOPE | W2 evidence files | PR #78 and PR #79 merged | Checks accepted before merge | ALP-CTRL-010 carried forward |
-| W3 | Progress + Completion | CLOSABLE AFTER PR #83 MERGE | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-082-decision-deployed-proof-closure.md`; `modules/ALP/11-build/evidence/20260702-W3-GOV-ALP-083-decision-db-progress-closure.md` | PR #80 and PR #81 merged; PR #82 deployed UI proof only; PR #83 pending | Pending PR #83 checks | ALP-CTRL-011 closes only after PR #83 merge; ALP-CTRL-010 remains open |
-| W4 | Enrolment + Payments | WAITING / NOT AUTHORIZED | Pending W4 evidence | No W4 PR yet | No checks run | Requires PR #83 merge for W3 closure |
+| W3 | Progress + Completion | CLOSED FOR APPROVED W3 SCOPE | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-082-decision-deployed-proof-closure.md`; `modules/ALP/11-build/evidence/20260702-W3-GOV-ALP-083-decision-db-progress-closure.md` | PR #80 and PR #81 merged; PR #82 deployed UI proof only; PR #83 merged | PR #83 merged | ALP-CTRL-011 closed; ALP-CTRL-010 remains open |
+| W4 | Enrolment + Payments | WAITING / AUTHORIZED FOR ENTRY | Pending W4 evidence | No W4 PR yet | No checks run | Requires W4 entry PR and evidence; carry ALP-CTRL-010 forward |
 | W5 | Assessment Submission | WAITING | Pending W5 evidence | No W5 PR yet | No checks run | Requires W1/W3/W4 closure |
 | W6 | AI Evaluation + Human Review | WAITING | Pending W6 evidence | No W6 PR yet | No checks run | Requires W5 closure |
 | W7 | Certificates | WAITING | Pending W7 evidence | No W7 PR yet | No checks run | Requires W3/W6 closure |
@@ -76,13 +76,13 @@
 | ALP-CTRL-005 | FUNCTIONAL_PASS not claimed | Open | Claim only after functional evidence exists. |
 | ALP-CTRL-006 | CWT_PASS not claimed | Open | Claim only after deployment/CWT evidence exists. |
 | ALP-CTRL-010 | Legacy iSpring embedded video objects do not consistently play. | Open | Inspect exported iSpring asset references, video file availability, MIME type, and browser errors. Owner wave: W3 content-hardening or later content QA. |
-| ALP-CTRL-011 | Live Supabase progress tables must be applied or verified before database-backed progress becomes the long-term source of truth. | Closable by PR #83 after merge | PR #83 records live migration verification for `public.progress_events`, `public.learner_progress`, and `public.completion_states`, plus `vpshr-level-0` / `introduction` proof rows; close only after merge and before W4 entry. |
+| ALP-CTRL-011 | Live Supabase progress tables must be applied or verified before database-backed progress becomes the long-term source of truth. | Closed by PR #83 | PR #83 records live migration verification for `public.progress_events`, `public.learner_progress`, and `public.completion_states`, plus `vpshr-level-0` / `introduction` proof rows. |
 
 ---
 
 ## Immediate Next Action
 
-Merge PR #83 to close ALP-CTRL-011. Do not start W4 until PR #83 is merged.
+Open W4 entry / implementation governance PR. Carry ALP-CTRL-010 forward and keep all non-claims intact.
 
 ---
 
@@ -90,14 +90,14 @@ Merge PR #83 to close ALP-CTRL-011. Do not start W4 until PR #83 is merged.
 
 W1 Closure: CLOSED FOR W1 SCOPE  
 W2 Closure: CLOSED FOR W2 SCOPE  
-W3 Closure: NOT CLAIMED until PR #83 is merged  
-W4 Start: NOT AUTHORIZED until PR #83 is merged  
+W3 Closure: CLOSED FOR APPROVED W3 SCOPE BY PR #83  
+W4 Start: AUTHORIZED FOR ENTRY AFTER PR #83 MERGE  
 Full App Delivery: NOT CLAIMED  
 CODE_PASS: NOT CLAIMED  
 FUNCTIONAL_PASS: NOT CLAIMED  
 CWT_PASS: NOT CLAIMED  
 Final content quality acceptance: NOT CLAIMED  
-Long-term database-backed progress source of truth: NOT CLAIMED until ALP-CTRL-011 is closed  
+Long-term database-backed progress source of truth: CLAIMED FOR W3 PROGRESS SCOPE ONLY  
 Deployment acceptance: NOT CLAIMED  
 Production readiness: NOT CLAIMED
 
@@ -112,5 +112,6 @@ Production readiness: NOT CLAIMED
 | 2.1 | 2026-06-30 | Filed W2 deployed proof closure and carried ALP-CTRL-010 forward. | AI-assisted draft | Merged by PR #79 |
 | 3.0 | 2026-06-30 | Filed W3 progress/completion implementation slice. | AI-assisted draft | Merged by PR #80 |
 | 3.1 | 2026-07-01 | Filed W3 progress proof fix after reviewer browser proof showed progress did not visibly update. | AI-assisted draft | Merged by PR #81 |
-| 3.2 | 2026-07-01 | Filed W3 deployed UI proof and kept W3 open pending ALP-CTRL-011 DB proof. | AI-assisted draft | Filed for review |
-| 3.3 | 2026-07-02 | Filed W3 database-backed progress proof as the closure PR; kept PR #82 as deployed UI proof only and left W4 blocked until merge. | AI-assisted draft | Filed for review as PR #83 |
+| 3.2 | 2026-07-01 | Filed W3 deployed UI proof and kept W3 open pending ALP-CTRL-011 DB proof. | AI-assisted draft | Filed by PR #82 as UI proof only |
+| 3.3 | 2026-07-02 | Filed W3 database-backed progress proof as the closure PR; kept PR #82 as deployed UI proof only and left W4 blocked until merge. | AI-assisted draft | Merged by PR #83 |
+| 3.4 | 2026-07-02 | Normalized GOV-ALP-083 post-merge status header and tracker posture after PR #83 merge. | AI-assisted draft | Filed for follow-up review |

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -112,6 +112,6 @@ Production readiness: NOT CLAIMED
 | 2.1 | 2026-06-30 | Filed W2 deployed proof closure and carried ALP-CTRL-010 forward. | AI-assisted draft | Merged by PR #79 |
 | 3.0 | 2026-06-30 | Filed W3 progress/completion implementation slice. | AI-assisted draft | Merged by PR #80 |
 | 3.1 | 2026-07-01 | Filed W3 progress proof fix after reviewer browser proof showed progress did not visibly update. | AI-assisted draft | Merged by PR #81 |
-| 3.2 | 2026-07-01 | Filed W3 deployed UI proof and kept W3 open pending ALP-CTRL-011 DB proof. | AI-assisted draft | Filed by PR #82 as UI proof only |
+| 3.2 | 2026-07-01 | Filed W3 deployed UI proof and kept W3 open pending ALP-CTRL-011 DB proof. | AI-assisted draft | Merged by PR #82 as deployed UI proof only |
 | 3.3 | 2026-07-02 | Filed W3 database-backed progress proof as the closure PR; kept PR #82 as deployed UI proof only and left W4 blocked until merge. | AI-assisted draft | Merged by PR #83 |
 | 3.4 | 2026-07-02 | Normalized GOV-ALP-083 post-merge status header and tracker posture after PR #83 merge. | AI-assisted draft | Filed for follow-up review |


### PR DESCRIPTION
Normalizes the W3 database-backed closure evidence after PR #83 was merged.

Summary:
- Adds the standard ALP status header to GOV-ALP-083.
- Updates BUILD_PROGRESS_TRACKER.md from PR #83 pending posture to merged / W3 closed posture.
- Updates the evidence index from PR #83 pending posture to merged / W3 closed posture.
- Records ALP-CTRL-011 as closed by PR #83.
- Carries ALP-CTRL-010 forward.

Non-claims preserved:
- No full app delivery claim.
- No CODE_PASS claim.
- No FUNCTIONAL_PASS claim.
- No CWT_PASS claim.
- No deployment acceptance or production readiness claim.

Scope:
- Governance evidence/status artifacts only.
- No app code, migration, package, generated asset, or runtime changes.