### PR TITLE
Implement ALP W4.1 enrolment state and course access gating

### DIFF
--- a/app/(learner)/learn/[courseSlug]/page.tsx
+++ b/app/(learner)/learn/[courseSlug]/page.tsx
@@ -1,7 +1,9 @@
 import { notFound } from "next/navigation";
+import { CourseAccessDenied } from "@/components/course/CourseAccessDenied";
 import { CourseShell } from "@/components/course/CourseShell";
 import { getCourseBySlug } from "@/lib/courses";
 import { getCourseShell } from "@/lib/services/courses/get-course-shell";
+import { getCourseAccess } from "@/lib/services/enrolments/get-course-access";
 import { getLearnerProgress } from "@/lib/services/progress/get-learner-progress";
 import { requireSession } from "@/server/auth/session";
 import { getCookieCompletedUnitIds } from "@/server/progress/progress-cookie";
@@ -29,6 +31,16 @@ export default async function Page({ params, searchParams }: PageProps) {
 
   if (!course) {
     notFound();
+  }
+
+  const access = await getCourseAccess({
+    accessToken: session.accessToken,
+    userId: session.user.id,
+    courseId: course.id
+  });
+
+  if (!access.canAccess) {
+    return <CourseAccessDenied course={course} access={access} />;
   }
 
   const [progress, cookieCompletedUnitIds] = await Promise.all([

--- a/app/(learner)/learn/[courseSlug]/units/[unitSlug]/page.tsx
+++ b/app/(learner)/learn/[courseSlug]/units/[unitSlug]/page.tsx
@@ -1,8 +1,10 @@
 import { notFound } from "next/navigation";
+import { CourseAccessDenied } from "@/components/course/CourseAccessDenied";
 import { UnitViewer } from "@/components/course/UnitViewer";
 import { getCourseBySlug } from "@/lib/courses";
 import { getCourseShell } from "@/lib/services/courses/get-course-shell";
 import { getUnitContent } from "@/lib/services/courses/get-unit-content";
+import { getCourseAccess } from "@/lib/services/enrolments/get-course-access";
 import { getLearnerProgress } from "@/lib/services/progress/get-learner-progress";
 import { requireSession } from "@/server/auth/session";
 import { getCookieCompletedUnitIds } from "@/server/progress/progress-cookie";
@@ -23,6 +25,16 @@ export default async function Page({ params }: PageProps) {
 
   if (!course) {
     notFound();
+  }
+
+  const access = await getCourseAccess({
+    accessToken: session.accessToken,
+    userId: session.user.id,
+    courseId: course.id
+  });
+
+  if (!access.canAccess) {
+    return <CourseAccessDenied course={course} access={access} />;
   }
 
   const [progress, cookieCompletedUnitIds] = await Promise.all([

--- a/modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-086-decision-enrolment-access-gating.md
+++ b/modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-086-decision-enrolment-access-gating.md
@@ -1,0 +1,112 @@
+# W4.1 Enrolment State and Course Access Gating Evidence
+
+## Status
+
+| Field | Value |
+|---|---|
+| Module | ALP - APGI Learning Portal |
+| Wave | W4.1 - Enrolment state and course access gating |
+| Evidence Type | Implementation slice evidence |
+| Date | 2026-07-02 |
+| Status | Filed for implementation review |
+| Branch | `alp-w4-1-enrolment-access-gating` |
+| Planned PR | W4.1 implementation PR |
+| Repository | APGI-cmy/Training |
+
+---
+
+## Decision
+
+W4.1 implements the first W4 build slice: database-backed learner-course enrolment state and route-level course access gating.
+
+This slice gates the learner course shell and unit viewer before progress data or course unit content is loaded. It creates the foundation needed before any payment gateway, payment lifecycle, or live payment readiness work.
+
+---
+
+## Implementation Summary
+
+| Area | Implementation |
+|---|---|
+| Database schema | Adds `public.course_enrolments` and `public.course_enrolment_events`. |
+| Enrolment statuses | Supports `pending`, `enrolled`, and `revoked`; missing row is handled in application logic as `not_enrolled`. |
+| RLS | Enables RLS for enrolment and enrolment-event tables. |
+| Access service | Adds `getCourseAccess` to resolve learner-course access from Supabase REST. |
+| Course shell gate | Blocks `/learn/[courseSlug]` unless access decision allows the learner to view the course shell. |
+| Unit viewer gate | Blocks `/learn/[courseSlug]/units/[unitSlug]` unless access decision allows the learner to view unit content. |
+| Denied-state UI | Adds `CourseAccessDenied` for governed negative-path proof. |
+| Static QA | Adds W4.1 QA coverage for schema, RLS, service, and route gating. |
+
+---
+
+## Acceptance Evidence
+
+| Gate | Evidence |
+|---|---|
+| Enrolment source of truth exists | `supabase/migrations/005_alp_enrolments_access.sql` creates `course_enrolments`. |
+| Enrolment audit trail exists | `supabase/migrations/005_alp_enrolments_access.sql` creates `course_enrolment_events`. |
+| Learner course access has explicit statuses | Migration check constraint permits `pending`, `enrolled`, and `revoked`; missing row is treated as `not_enrolled`. |
+| Route access gate exists | Course shell and unit viewer call `getCourseAccess` before loading gated course content. |
+| Negative path exists | `CourseAccessDenied` renders the status and reason when access is not allowed. |
+| Payment readiness not claimed | This PR adds no payment provider, payment code, live payment flow, or payment compliance claim. |
+
+---
+
+## Golden Path
+
+An authenticated learner with a `course_enrolments` row in status `enrolled` can access:
+
+- `/learn/[courseSlug]`
+- `/learn/[courseSlug]/units/[unitSlug]`
+
+The learner can then continue the existing W3 progress/completion flow.
+
+---
+
+## Negative Paths
+
+A learner must not access gated course content when:
+
+- no enrolment row exists;
+- enrolment status is `pending`;
+- enrolment status is `revoked`;
+- Supabase enrolment access cannot be resolved.
+
+In these cases the learner receives the governed access-denied state instead of the course shell or unit viewer.
+
+---
+
+## Carry-Forward Controls
+
+| Control ID | Status | W4.1 Treatment |
+|---|---|---|
+| ALP-CTRL-003 | Open | Full app workflows remain incomplete until W4-W9 closure. |
+| ALP-CTRL-004 | Open | CODE_PASS remains not claimed. |
+| ALP-CTRL-005 | Open | FUNCTIONAL_PASS remains not claimed. |
+| ALP-CTRL-006 | Open | CWT_PASS remains not claimed. |
+| ALP-CTRL-010 | Open | Legacy iSpring embedded video playback remains open and carried forward. |
+| ALP-CTRL-011 | Closed by PR #83 | No W4.1 regression expected; W3 progress source of truth remains unchanged. |
+
+---
+
+## Non-Claims
+
+This W4.1 slice does not claim:
+
+- Full app delivery.
+- CODE_PASS.
+- FUNCTIONAL_PASS.
+- CWT_PASS.
+- Deployment acceptance.
+- Production readiness.
+- Live payment readiness.
+- Payment gateway compliance.
+- W4 closure.
+- W4 payment implementation closure.
+
+---
+
+## Next Required Action
+
+After review and merge, apply/verify migration `005_alp_enrolments_access.sql` in Supabase and capture live DB proof before closing W4.1 as fully accepted.
+
+Recommended next build slice after DB proof: W4.2 Manual/admin enrolment path and audit trail management.

--- a/modules/ALP/11-build/evidence/index.md
+++ b/modules/ALP/11-build/evidence/index.md
@@ -6,7 +6,7 @@
 |---|---|
 | Module | ALP - APGI Learning Portal |
 | Artifact | Build Evidence Index |
-| Status | Updated for W4 entry governance |
+| Status | Updated for W4.1 enrolment access gating |
 | Date | 2026-07-02 |
 | Repository | APGI-cmy/Training |
 | Canonical Path | `modules/ALP/11-build/evidence/index.md` |
@@ -24,7 +24,8 @@
 | W3 | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-081-decision-progress-proof-fix.md` | GOV-ALP-081; progress-proof | W3 progress proof fix path | GitHub PR evidence / reviewer proof | PR #81 / `27f96a9efb9294158ed16b47524ceeeabbb93892` | Vercel accepted before merge | BC-ALP-CONSOLIDATED-001 / reviewer proof | Merged | Visible progress recording fixed. |
 | W3 | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-082-decision-deployed-proof-closure.md` | GOV-ALP-082; deployed-ui-proof | W3 deployed UI proof path | Deployed app / reviewer screenshot | PR #82 / merged | Merged | BC-ALP-CONSOLIDATED-001 / reviewer proof | Deployed UI proof only | PR #82 did not close W3 or authorize W4; ALP-CTRL-011 still required database proof. |
 | W3 | `modules/ALP/11-build/evidence/20260702-W3-GOV-ALP-083-decision-db-progress-closure.md` | GOV-ALP-083; db-progress-proof; ALP-CTRL-011 | W3 database-backed progress closure path | Live Supabase / GitHub PR evidence | PR #83 / `55c686aeda1dc293d6ad6de72526f86e2cb488c9` | Merged | BC-ALP-CONSOLIDATED-001 | Closed for approved W3 scope | Live migration verified for `public.progress_events`, `public.learner_progress`, and `public.completion_states`; `vpshr-level-0` / `introduction` proof rows captured as `unit_completed`, `completed`, and `1 of 13`, `7.69%`. |
-| W4 | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-085-decision-enrolment-payments-entry.md` | GOV-ALP-085; enrolment-payments-entry | W4 enrolment + payments entry path | GitHub PR evidence | Pending W4 entry PR | Pending review | BC-ALP-CONSOLIDATED-001 | Entry filed; not closed | Opens W4 governance only; no app/runtime/payment code or payment readiness claim. |
+| W4 | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-085-decision-enrolment-payments-entry.md` | GOV-ALP-085; enrolment-payments-entry | W4 enrolment + payments entry path | GitHub PR evidence | PR #85 / `1179887489a1e0f2dddc364b837b99251ee2adbb` | Merged | BC-ALP-CONSOLIDATED-001 | Entry merged; not closed | Opens W4 governance only; no app/runtime/payment code or payment readiness claim. |
+| W4.1 | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-086-decision-enrolment-access-gating.md` | GOV-ALP-086; enrolment-access-gating; QA-ALP-241-244 | Enrolled learner allowed; not enrolled/pending/revoked denied | GitHub PR evidence / Supabase migration | Pending W4.1 PR | Pending review | BC-ALP-CONSOLIDATED-001 | Implementation filed; DB proof pending | Adds database-backed enrolment/access gate foundation; live Supabase application proof still required before W4.1 closure. |
 
 ---
 
@@ -39,4 +40,5 @@ Deployment acceptance: NOT CLAIMED.
 Production readiness: NOT CLAIMED.  
 Live payment readiness: NOT CLAIMED.  
 ALP-CTRL-010: OPEN and carried forward.  
-W4: ENTRY FILED, but W4 implementation/closure is NOT CLAIMED.
+W4: IMPLEMENTATION STARTED, but W4 implementation/closure is NOT CLAIMED.  
+W4.1: IMPLEMENTATION FILED, but live DB proof/closure is NOT CLAIMED.

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -3,11 +3,11 @@
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
 **Last Updated**: 2026-07-02  
-**Updated By**: GOV-ALP-085 W4 entry governance  
-> **Classification**: ACTIVE - W4 ENTRY FILED FOR REVIEW  
+**Updated By**: GOV-ALP-086 W4.1 enrolment access gating  
+> **Classification**: ACTIVE - W4.1 IMPLEMENTATION FILED FOR REVIEW  
 > **Repository**: APGI-cmy/Training  
-> **Current Workstream**: W4 Enrolment + Payments entry governance  
-> **Next Required Action**: Review and merge W4 entry PR before starting W4 implementation slice
+> **Current Workstream**: W4.1 Enrolment state and course access gating  
+> **Next Required Action**: Review W4.1 PR, then apply/verify Supabase migration 005 before closure
 
 ---
 
@@ -19,7 +19,8 @@
 | W1 Closure / W2 Entry | Closed for W1 scope | PR #77 / `f492c8efd8c83cbca49481191315ac2869c62c3b` |
 | W2 Dashboard / Course Shell / Unit Viewer | Closed for W2 scope | PR #79 / `1b2ae564437a90349ccca95138ac430bf680089b` |
 | W3 Progress + Completion | Closed for approved W3 database-backed progress scope | PR #80 and PR #81 merged; PR #82 deployed UI proof only; PR #83 merged; PR #84 normalized post-merge evidence |
-| W4 Enrolment + Payments | Entry filed for review | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-085-decision-enrolment-payments-entry.md` |
+| W4 Enrolment + Payments | Entry merged; implementation started | PR #85 merged; W4.1 implementation filed for review |
+| W4.1 Enrolment state and access gating | Implementation filed for review; live DB proof pending | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-086-decision-enrolment-access-gating.md` |
 
 ---
 
@@ -54,11 +55,26 @@
 
 | Entry Item | Status |
 |---|---|
-| W4 entry evidence | Filed for review. |
-| W4 implementation | Not started in this entry PR. |
+| W4 entry evidence | Merged by PR #85. |
+| W4 implementation | Started with W4.1 implementation PR. |
 | Initial recommended slice | W4.1 Enrolment state and course access gating. |
-| Payment gateway integration | Not authorized by this entry PR. Requires later gateway decision and sandbox proof. |
+| Payment gateway integration | Not authorized by W4.1. Requires later gateway decision and sandbox proof. |
 | ALP-CTRL-010 | Open and carried forward. |
+
+---
+
+## W4.1 Implementation Filed
+
+| Proof Item | Status |
+|---|---|
+| Enrolment table | Added as `public.course_enrolments` in migration `005_alp_enrolments_access.sql`. |
+| Enrolment event table | Added as `public.course_enrolment_events` for audit trail. |
+| Enrolment statuses | `pending`, `enrolled`, `revoked`; application treats missing row as `not_enrolled`. |
+| Course shell gate | `/learn/[courseSlug]` now checks `getCourseAccess` before loading progress/course content. |
+| Unit viewer gate | `/learn/[courseSlug]/units/[unitSlug]` now checks `getCourseAccess` before loading unit content. |
+| Negative path | `CourseAccessDenied` renders governed denied state. |
+| Static QA | `tests/qa-to-red/alp/enrolment-access.spec.ts` added. |
+| Live DB proof | Pending; required before W4.1 closure. |
 
 ---
 
@@ -70,7 +86,7 @@
 | W1 | Auth + Profile + Files | CLOSED FOR W1 SCOPE | W1 evidence files | PR #73-#77 merged | Checks accepted before merge | Admin console proof deferred |
 | W2 | Dashboard + Course Shell + Unit Viewer | CLOSED FOR W2 SCOPE | W2 evidence files | PR #78 and PR #79 merged | Checks accepted before merge | ALP-CTRL-010 carried forward |
 | W3 | Progress + Completion | CLOSED FOR APPROVED W3 SCOPE | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-082-decision-deployed-proof-closure.md`; `modules/ALP/11-build/evidence/20260702-W3-GOV-ALP-083-decision-db-progress-closure.md` | PR #80 and PR #81 merged; PR #82 deployed UI proof only; PR #83 merged; PR #84 merged | PR #83 and PR #84 merged | ALP-CTRL-011 closed; ALP-CTRL-010 remains open |
-| W4 | Enrolment + Payments | ENTRY FILED FOR REVIEW | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-085-decision-enrolment-payments-entry.md` | W4 entry PR pending | Checks pending | Requires W4 entry review/merge before implementation closure |
+| W4 | Enrolment + Payments | IMPLEMENTATION STARTED | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-085-decision-enrolment-payments-entry.md`; `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-086-decision-enrolment-access-gating.md` | PR #85 merged; W4.1 PR pending | Checks pending | W4.1 live DB proof pending; no payment readiness claim |
 | W5 | Assessment Submission | WAITING | Pending W5 evidence | No W5 PR yet | No checks run | Requires W1/W3/W4 closure |
 | W6 | AI Evaluation + Human Review | WAITING | Pending W6 evidence | No W6 PR yet | No checks run | Requires W5 closure |
 | W7 | Certificates | WAITING | Pending W7 evidence | No W7 PR yet | No checks run | Requires W3/W6 closure |
@@ -94,7 +110,7 @@
 
 ## Immediate Next Action
 
-Review and merge the W4 entry governance PR. After merge, open W4.1 implementation for enrolment state and course access gating.
+Review W4.1 implementation PR. After merge, apply and verify `005_alp_enrolments_access.sql` in Supabase and capture live DB proof before W4.1 closure.
 
 ---
 
@@ -103,8 +119,9 @@ Review and merge the W4 entry governance PR. After merge, open W4.1 implementati
 W1 Closure: CLOSED FOR W1 SCOPE  
 W2 Closure: CLOSED FOR W2 SCOPE  
 W3 Closure: CLOSED FOR APPROVED W3 SCOPE BY PR #83  
-W4 Start: ENTRY FILED FOR REVIEW  
-W4 Implementation Closure: NOT CLAIMED  
+W4 Entry: MERGED BY PR #85  
+W4 Start: IMPLEMENTATION STARTED WITH W4.1  
+W4.1 Implementation Closure: NOT CLAIMED  
 Full App Delivery: NOT CLAIMED  
 CODE_PASS: NOT CLAIMED  
 FUNCTIONAL_PASS: NOT CLAIMED  
@@ -129,4 +146,5 @@ Production readiness: NOT CLAIMED
 | 3.2 | 2026-07-01 | Filed W3 deployed UI proof and kept W3 open pending ALP-CTRL-011 DB proof. | AI-assisted draft | Merged by PR #82 as deployed UI proof only |
 | 3.3 | 2026-07-02 | Filed W3 database-backed progress proof as the closure PR; kept PR #82 as deployed UI proof only and left W4 blocked until merge. | AI-assisted draft | Merged by PR #83 |
 | 3.4 | 2026-07-02 | Normalized GOV-ALP-083 post-merge status header and tracker posture after PR #83 merge. | AI-assisted draft | Merged by PR #84 |
-| 4.0 | 2026-07-02 | Filed W4 enrolment and payments entry governance. | AI-assisted draft | Filed for W4 entry review |
+| 4.0 | 2026-07-02 | Filed W4 enrolment and payments entry governance. | AI-assisted draft | Merged by PR #85 |
+| 4.1 | 2026-07-02 | Filed W4.1 enrolment state and course access gating implementation. | AI-assisted draft | Filed for W4.1 review |

--- a/src/components/course/CourseAccessDenied.tsx
+++ b/src/components/course/CourseAccessDenied.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import type { CourseAccessDecision } from "@/lib/services/enrolments/get-course-access";
+import type { Course } from "@/types/course";
+
+export function CourseAccessDenied({
+  course,
+  access
+}: {
+  course: Course;
+  access: CourseAccessDecision;
+}) {
+  const statusLabel = access.status.replace("_", " ");
+
+  return (
+    <main>
+      <section className="course-masthead">
+        <div className="content-inner">
+          <Link className="back-link" href="/dashboard">
+            Back to dashboard
+          </Link>
+          <p className="eyebrow">W4 enrolment access gate</p>
+          <h1>Course access pending</h1>
+          <p>
+            {course.title} is available only when your enrolment status grants access to this course.
+          </p>
+          <p role="status">Current enrolment status: {statusLabel}.</p>
+          <p>{access.reason}</p>
+          <div className="button-row">
+            <Link className="primary-button" href={`/courses/${course.slug}`}>
+              View course overview
+            </Link>
+            <Link className="secondary-button" href="/dashboard">
+              Return to dashboard
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/course/CourseAccessDenied.tsx
+++ b/src/components/course/CourseAccessDenied.tsx
@@ -2,6 +2,22 @@ import Link from "next/link";
 import type { CourseAccessDecision } from "@/lib/services/enrolments/get-course-access";
 import type { Course } from "@/types/course";
 
+function deniedHeading(status: CourseAccessDecision["status"]): string {
+  if (status === "pending") {
+    return "Course access pending";
+  }
+
+  if (status === "revoked") {
+    return "Course access revoked";
+  }
+
+  if (status === "unknown") {
+    return "Course access unavailable";
+  }
+
+  return "Course access required";
+}
+
 export function CourseAccessDenied({
   course,
   access
@@ -19,17 +35,14 @@ export function CourseAccessDenied({
             Back to dashboard
           </Link>
           <p className="eyebrow">W4 enrolment access gate</p>
-          <h1>Course access pending</h1>
+          <h1>{deniedHeading(access.status)}</h1>
           <p>
             {course.title} is available only when your enrolment status grants access to this course.
           </p>
           <p role="status">Current enrolment status: {statusLabel}.</p>
           <p>{access.reason}</p>
           <div className="button-row">
-            <Link className="primary-button" href={`/courses/${course.slug}`}>
-              View course overview
-            </Link>
-            <Link className="secondary-button" href="/dashboard">
+            <Link className="primary-button" href="/dashboard">
               Return to dashboard
             </Link>
           </div>

--- a/src/lib/services/enrolments/get-course-access.ts
+++ b/src/lib/services/enrolments/get-course-access.ts
@@ -1,6 +1,6 @@
 import { getSupabaseRestUrl } from "@/server/auth/session";
 
-export type CourseEnrolmentStatus = "not_enrolled" | "pending" | "enrolled" | "revoked";
+export type CourseEnrolmentStatus = "not_enrolled" | "pending" | "enrolled" | "revoked" | "unknown";
 
 export interface CourseAccessDecision {
   courseId: string;
@@ -42,6 +42,16 @@ export function notEnrolledDecision(userId: string, courseId: string): CourseAcc
   };
 }
 
+export function unknownAccessDecision(userId: string, courseId: string): CourseAccessDecision {
+  return {
+    courseId,
+    userId,
+    status: "unknown",
+    canAccess: false,
+    reason: "Course access could not be verified. Please try again or contact support."
+  };
+}
+
 export async function getCourseAccess({
   accessToken,
   userId,
@@ -57,7 +67,7 @@ export async function getCourseAccess({
   );
 
   if (!headers || !url) {
-    return notEnrolledDecision(userId, courseId);
+    return unknownAccessDecision(userId, courseId);
   }
 
   const response = await fetch(url, {
@@ -67,10 +77,17 @@ export async function getCourseAccess({
   });
 
   if (!response.ok) {
-    return notEnrolledDecision(userId, courseId);
+    return unknownAccessDecision(userId, courseId);
   }
 
-  const rows = (await response.json().catch(() => [])) as CourseEnrolmentRow[];
+  let rows: CourseEnrolmentRow[];
+
+  try {
+    rows = (await response.json()) as CourseEnrolmentRow[];
+  } catch {
+    return unknownAccessDecision(userId, courseId);
+  }
+
   const enrolment = rows[0];
 
   if (!enrolment?.status) {

--- a/src/lib/services/enrolments/get-course-access.ts
+++ b/src/lib/services/enrolments/get-course-access.ts
@@ -1,0 +1,113 @@
+import { getSupabaseRestUrl } from "@/server/auth/session";
+
+export type CourseEnrolmentStatus = "not_enrolled" | "pending" | "enrolled" | "revoked";
+
+export interface CourseAccessDecision {
+  courseId: string;
+  userId: string;
+  status: CourseEnrolmentStatus;
+  canAccess: boolean;
+  reason: string;
+  accessGrantedAt?: string | null;
+  accessRevokedAt?: string | null;
+}
+
+interface CourseEnrolmentRow {
+  status?: "pending" | "enrolled" | "revoked";
+  access_granted_at?: string | null;
+  access_revoked_at?: string | null;
+}
+
+function enrolmentHeaders(accessToken: string) {
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!anonKey) {
+    return null;
+  }
+
+  return {
+    apikey: anonKey,
+    authorization: `Bearer ${accessToken}`,
+    "content-type": "application/json"
+  };
+}
+
+export function notEnrolledDecision(userId: string, courseId: string): CourseAccessDecision {
+  return {
+    courseId,
+    userId,
+    status: "not_enrolled",
+    canAccess: false,
+    reason: "No enrolment record exists for this learner and course."
+  };
+}
+
+export async function getCourseAccess({
+  accessToken,
+  userId,
+  courseId
+}: {
+  accessToken: string;
+  userId: string;
+  courseId: string;
+}): Promise<CourseAccessDecision> {
+  const headers = enrolmentHeaders(accessToken);
+  const url = getSupabaseRestUrl(
+    `/rest/v1/course_enrolments?select=status,access_granted_at,access_revoked_at&user_id=eq.${userId}&course_id=eq.${courseId}&limit=1`
+  );
+
+  if (!headers || !url) {
+    return notEnrolledDecision(userId, courseId);
+  }
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers,
+    cache: "no-store"
+  });
+
+  if (!response.ok) {
+    return notEnrolledDecision(userId, courseId);
+  }
+
+  const rows = (await response.json().catch(() => [])) as CourseEnrolmentRow[];
+  const enrolment = rows[0];
+
+  if (!enrolment?.status) {
+    return notEnrolledDecision(userId, courseId);
+  }
+
+  if (enrolment.status === "enrolled") {
+    return {
+      courseId,
+      userId,
+      status: "enrolled",
+      canAccess: true,
+      reason: "Learner has an active course enrolment.",
+      accessGrantedAt: enrolment.access_granted_at ?? null,
+      accessRevokedAt: enrolment.access_revoked_at ?? null
+    };
+  }
+
+  if (enrolment.status === "revoked") {
+    return {
+      courseId,
+      userId,
+      status: "revoked",
+      canAccess: false,
+      reason: "Learner course access has been revoked.",
+      accessGrantedAt: enrolment.access_granted_at ?? null,
+      accessRevokedAt: enrolment.access_revoked_at ?? null
+    };
+  }
+
+  return {
+    courseId,
+    userId,
+    status: "pending",
+    canAccess: false,
+    reason: "Learner enrolment is pending and does not grant course access yet.",
+    accessGrantedAt: enrolment.access_granted_at ?? null,
+    accessRevokedAt: enrolment.access_revoked_at ?? null
+  };
+}

--- a/src/lib/services/enrolments/get-course-access.ts
+++ b/src/lib/services/enrolments/get-course-access.ts
@@ -38,7 +38,7 @@ export function notEnrolledDecision(userId: string, courseId: string): CourseAcc
     userId,
     status: "not_enrolled",
     canAccess: false,
-    reason: "No enrolment record exists for this learner and course."
+    reason: "Course access could not be confirmed (enrolment missing or access check failed)."
   };
 }
 

--- a/supabase/migrations/005_alp_enrolments_access.sql
+++ b/supabase/migrations/005_alp_enrolments_access.sql
@@ -46,34 +46,6 @@ using (
   )
 );
 
-drop policy if exists course_enrolments_insert_self_pending on public.course_enrolments;
-create policy course_enrolments_insert_self_pending
-on public.course_enrolments
-for insert
-with check (
-  user_id = auth.uid()
-  and status = 'pending'
-);
-
-drop policy if exists course_enrolments_admin_write on public.course_enrolments;
-create policy course_enrolments_admin_write
-on public.course_enrolments
-for all
-using (
-  exists (
-    select 1 from public.user_roles ur
-    where ur.user_id = auth.uid()
-      and ur.role = 'admin'
-  )
-)
-with check (
-  exists (
-    select 1 from public.user_roles ur
-    where ur.user_id = auth.uid()
-      and ur.role = 'admin'
-  )
-);
-
 drop policy if exists course_enrolment_events_select_self_or_admin on public.course_enrolment_events;
 create policy course_enrolment_events_select_self_or_admin
 on public.course_enrolment_events
@@ -87,18 +59,8 @@ using (
   )
 );
 
-drop policy if exists course_enrolment_events_insert_self_or_admin on public.course_enrolment_events;
-create policy course_enrolment_events_insert_self_or_admin
-on public.course_enrolment_events
-for insert
-with check (
-  user_id = auth.uid()
-  or exists (
-    select 1 from public.user_roles ur
-    where ur.user_id = auth.uid()
-      and ur.role = 'admin'
-  )
-);
+-- W4.1 is read-gating only. Enrolment writes are intentionally deferred to W4.2 admin/manual enrolment.
+-- No public enrolment insert/update policies are created in this migration.
 
 drop trigger if exists set_course_enrolments_updated_at on public.course_enrolments;
 create trigger set_course_enrolments_updated_at

--- a/supabase/migrations/005_alp_enrolments_access.sql
+++ b/supabase/migrations/005_alp_enrolments_access.sql
@@ -1,0 +1,106 @@
+-- ALP W4.1 - Enrolment state and course access gating schema
+
+create table if not exists public.course_enrolments (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  course_id text not null,
+  status text not null default 'pending' check (status in ('pending', 'enrolled', 'revoked')),
+  source text not null default 'manual' check (source in ('manual', 'admin', 'payment', 'migration', 'system')),
+  access_granted_at timestamptz,
+  access_revoked_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  unique (user_id, course_id)
+);
+
+create table if not exists public.course_enrolment_events (
+  id uuid primary key default gen_random_uuid(),
+  event_key text not null unique,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  course_id text not null,
+  event_type text not null check (event_type in ('enrolment_requested', 'enrolment_granted', 'enrolment_revoked', 'access_denied')),
+  previous_status text,
+  next_status text,
+  occurred_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_course_enrolments_user_course on public.course_enrolments(user_id, course_id);
+create index if not exists idx_course_enrolments_course_status on public.course_enrolments(course_id, status);
+create index if not exists idx_course_enrolment_events_user_course on public.course_enrolment_events(user_id, course_id);
+
+alter table public.course_enrolments enable row level security;
+alter table public.course_enrolment_events enable row level security;
+
+drop policy if exists course_enrolments_select_self_or_admin on public.course_enrolments;
+create policy course_enrolments_select_self_or_admin
+on public.course_enrolments
+for select
+using (
+  user_id = auth.uid()
+  or exists (
+    select 1 from public.user_roles ur
+    where ur.user_id = auth.uid()
+      and ur.role in ('admin', 'reviewer')
+  )
+);
+
+drop policy if exists course_enrolments_insert_self_pending on public.course_enrolments;
+create policy course_enrolments_insert_self_pending
+on public.course_enrolments
+for insert
+with check (
+  user_id = auth.uid()
+  and status = 'pending'
+);
+
+drop policy if exists course_enrolments_admin_write on public.course_enrolments;
+create policy course_enrolments_admin_write
+on public.course_enrolments
+for all
+using (
+  exists (
+    select 1 from public.user_roles ur
+    where ur.user_id = auth.uid()
+      and ur.role = 'admin'
+  )
+)
+with check (
+  exists (
+    select 1 from public.user_roles ur
+    where ur.user_id = auth.uid()
+      and ur.role = 'admin'
+  )
+);
+
+drop policy if exists course_enrolment_events_select_self_or_admin on public.course_enrolment_events;
+create policy course_enrolment_events_select_self_or_admin
+on public.course_enrolment_events
+for select
+using (
+  user_id = auth.uid()
+  or exists (
+    select 1 from public.user_roles ur
+    where ur.user_id = auth.uid()
+      and ur.role in ('admin', 'reviewer')
+  )
+);
+
+drop policy if exists course_enrolment_events_insert_self_or_admin on public.course_enrolment_events;
+create policy course_enrolment_events_insert_self_or_admin
+on public.course_enrolment_events
+for insert
+with check (
+  user_id = auth.uid()
+  or exists (
+    select 1 from public.user_roles ur
+    where ur.user_id = auth.uid()
+      and ur.role = 'admin'
+  )
+);
+
+drop trigger if exists set_course_enrolments_updated_at on public.course_enrolments;
+create trigger set_course_enrolments_updated_at
+before update on public.course_enrolments
+for each row execute function public.set_updated_at();

--- a/tests/qa-to-red/alp/enrolment-access.spec.ts
+++ b/tests/qa-to-red/alp/enrolment-access.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "vitest";
+import { expectContains, expectPath } from "./helpers/project-root";
+
+describe("ALP W4.1 enrolment state and course access gating", () => {
+  it("QA-ALP-241 enrolment schema and audit events exist", () => {
+    expectContains("supabase/migrations/005_alp_enrolments_access.sql", "course_enrolments", "QA-ALP-241");
+    expectContains("supabase/migrations/005_alp_enrolments_access.sql", "course_enrolment_events", "QA-ALP-241");
+    expectContains("supabase/migrations/005_alp_enrolments_access.sql", "status in ('pending', 'enrolled', 'revoked')", "QA-ALP-241");
+  });
+
+  it("QA-ALP-242 enrolment RLS policies exist", () => {
+    expectContains("supabase/migrations/005_alp_enrolments_access.sql", "alter table public.course_enrolments enable row level security", "QA-ALP-242");
+    expectContains("supabase/migrations/005_alp_enrolments_access.sql", "course_enrolments_select_self_or_admin", "QA-ALP-242");
+    expectContains("supabase/migrations/005_alp_enrolments_access.sql", "course_enrolments_admin_write", "QA-ALP-242");
+  });
+
+  it("QA-ALP-243 course access service exists", () => {
+    expectPath("src/lib/services/enrolments/get-course-access.ts", "QA-ALP-243");
+    expectContains("src/lib/services/enrolments/get-course-access.ts", "canAccess", "QA-ALP-243");
+    expectContains("src/lib/services/enrolments/get-course-access.ts", "not_enrolled", "QA-ALP-243");
+  });
+
+  it("QA-ALP-244 course shell and unit viewer are gated by enrolment access", () => {
+    expectContains("app/(learner)/learn/[courseSlug]/page.tsx", "getCourseAccess", "QA-ALP-244");
+    expectContains("app/(learner)/learn/[courseSlug]/page.tsx", "CourseAccessDenied", "QA-ALP-244");
+    expectContains("app/(learner)/learn/[courseSlug]/units/[unitSlug]/page.tsx", "getCourseAccess", "QA-ALP-244");
+    expectContains("app/(learner)/learn/[courseSlug]/units/[unitSlug]/page.tsx", "CourseAccessDenied", "QA-ALP-244");
+  });
+});

--- a/tests/qa-to-red/alp/enrolment-access.spec.ts
+++ b/tests/qa-to-red/alp/enrolment-access.spec.ts
@@ -8,16 +8,17 @@ describe("ALP W4.1 enrolment state and course access gating", () => {
     expectContains("supabase/migrations/005_alp_enrolments_access.sql", "status in ('pending', 'enrolled', 'revoked')", "QA-ALP-241");
   });
 
-  it("QA-ALP-242 enrolment RLS policies exist", () => {
+  it("QA-ALP-242 enrolment read-gating RLS policies exist", () => {
     expectContains("supabase/migrations/005_alp_enrolments_access.sql", "alter table public.course_enrolments enable row level security", "QA-ALP-242");
     expectContains("supabase/migrations/005_alp_enrolments_access.sql", "course_enrolments_select_self_or_admin", "QA-ALP-242");
-    expectContains("supabase/migrations/005_alp_enrolments_access.sql", "course_enrolments_admin_write", "QA-ALP-242");
+    expectContains("supabase/migrations/005_alp_enrolments_access.sql", "No public enrolment insert/update policies", "QA-ALP-242");
   });
 
   it("QA-ALP-243 course access service exists", () => {
     expectPath("src/lib/services/enrolments/get-course-access.ts", "QA-ALP-243");
     expectContains("src/lib/services/enrolments/get-course-access.ts", "canAccess", "QA-ALP-243");
     expectContains("src/lib/services/enrolments/get-course-access.ts", "not_enrolled", "QA-ALP-243");
+    expectContains("src/lib/services/enrolments/get-course-access.ts", "unknownAccessDecision", "QA-ALP-243");
   });
 
   it("QA-ALP-244 course shell and unit viewer are gated by enrolment access", () => {
@@ -25,5 +26,11 @@ describe("ALP W4.1 enrolment state and course access gating", () => {
     expectContains("app/(learner)/learn/[courseSlug]/page.tsx", "CourseAccessDenied", "QA-ALP-244");
     expectContains("app/(learner)/learn/[courseSlug]/units/[unitSlug]/page.tsx", "getCourseAccess", "QA-ALP-244");
     expectContains("app/(learner)/learn/[courseSlug]/units/[unitSlug]/page.tsx", "CourseAccessDenied", "QA-ALP-244");
+  });
+
+  it("QA-ALP-245 denied state does not link to ungated legacy course overview", () => {
+    expectPath("src/components/course/CourseAccessDenied.tsx", "QA-ALP-245");
+    expectContains("src/components/course/CourseAccessDenied.tsx", "deniedHeading", "QA-ALP-245");
+    expectContains("src/components/course/CourseAccessDenied.tsx", "Return to dashboard", "QA-ALP-245");
   });
 });


### PR DESCRIPTION
Implements the first W4 build slice after PR #85 merged W4 entry governance.

Summary:
- Adds Supabase migration `005_alp_enrolments_access.sql` with `course_enrolments` and `course_enrolment_events`.
- Adds read-gating RLS policies for learner/admin/reviewer enrolment visibility.
- Keeps enrolment creation and management deferred to W4.2 manual/admin enrolment.
- Adds `getCourseAccess` service to resolve learner-course access from Supabase REST.
- Gates the learner course shell route before loading progress/course content.
- Gates the unit viewer route before loading unit content.
- Adds `CourseAccessDenied` governed negative-path UI without linking to the legacy course overview.
- Adds static QA coverage for schema, RLS, service, route gating, and denied-state behavior.
- Adds W4.1 evidence and updates the ALP evidence index/tracker.
- Records PR #85 as merged and carries ALP-CTRL-010 forward.

Scope:
- W4.1 implementation slice only.
- Enrolment state and course access gating only.
- Read-gating foundation only; enrolment creation/management is deferred to W4.2.
- No payment gateway integration.
- No live payment readiness claim.
- No W4 closure claim.
- No full app delivery claim.

Non-claims preserved:
- No CODE_PASS claim.
- No FUNCTIONAL_PASS claim.
- No CWT_PASS claim.
- No deployment acceptance claim.
- No production readiness claim.
- No payment gateway compliance claim.

Closure posture:
- This PR files W4.1 implementation for review.
- Live Supabase application/verification of migration `005_alp_enrolments_access.sql` is still required before W4.1 can be closed as fully accepted.

Recommended next action after merge:
- Apply/verify migration `005_alp_enrolments_access.sql` in Supabase and capture live DB proof.
- Then open W4.1 closure proof or proceed to W4.2 only if governance accepts the residual DB-proof posture.