### PR TITLE
File ALP W4.2 executable QA-to-Red proof

### DIFF
--- a/.github/workflows/alp-w4-2-red-proof.yml
+++ b/.github/workflows/alp-w4-2-red-proof.yml
@@ -1,0 +1,63 @@
+name: ALP W4.2 RED Proof
+
+on:
+  pull_request:
+    paths:
+      - "tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts"
+      - "package.json"
+      - ".github/workflows/alp-w4-2-red-proof.yml"
+      - "modules/ALP/05-qa-to-red/**"
+      - "modules/ALP/11-build/evidence/**"
+      - "modules/ALP/BUILD_PROGRESS_TRACKER.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prove-correct-red:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Execute W4.2 RED suite
+        shell: bash
+        run: |
+          set +e
+          npm run test:alp:w4-2:red 2>&1 | tee w4-2-red-output.txt
+          test_status=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$test_status" -eq 0 ]; then
+            echo "W4.2 suite unexpectedly passed before implementation."
+            exit 1
+          fi
+
+          grep -Eq "16 failed|Tests[[:space:]]+16 failed" w4-2-red-output.txt
+          for id in $(seq 252 267); do
+            grep -q "QA-ALP-${id}" w4-2-red-output.txt
+          done
+
+          if grep -Eqi "failed to load|syntax error|transform error|no test files found|cannot find module.*vitest" w4-2-red-output.txt; then
+            echo "RED is invalid because the runner or test module failed."
+            exit 1
+          fi
+
+          echo "Correct RED established: all 16 W4.2 tests executed and failed on absent behaviour."
+
+      - name: Upload RED output
+        uses: actions/upload-artifact@v4
+        with:
+          name: alp-w4-2-red-output
+          path: w4-2-red-output.txt
+          if-no-files-found: error

--- a/.github/workflows/alp-w4-2-red-proof.yml
+++ b/.github/workflows/alp-w4-2-red-proof.yml
@@ -43,21 +43,32 @@ jobs:
             exit 1
           fi
 
-          grep -Eq "16 failed|Tests[[:space:]]+16 failed" w4-2-red-output.txt
+          sed -E 's/\x1B\[[0-9;]*[mK]//g' w4-2-red-output.txt > w4-2-red-output-clean.txt
+
+          grep -Eq "Test Files[[:space:]]+1 failed[[:space:]]+\(1\)" w4-2-red-output-clean.txt
+          grep -Eq "Tests[[:space:]]+16 failed[[:space:]]+\(16\)" w4-2-red-output-clean.txt
+
+          if grep -Eq "Tests.*[1-9][0-9]* passed|Tests.*[1-9][0-9]* skipped|Tests.*[1-9][0-9]* todo" w4-2-red-output-clean.txt; then
+            echo "RED is invalid because one or more W4.2 tests passed, skipped, or remained todo."
+            exit 1
+          fi
+
           for id in $(seq 252 267); do
-            grep -q "QA-ALP-${id}" w4-2-red-output.txt
+            grep -q "QA-ALP-${id}" w4-2-red-output-clean.txt
           done
 
-          if grep -Eqi "failed to load|syntax error|transform error|no test files found|cannot find module.*vitest" w4-2-red-output.txt; then
+          if grep -Eqi "failed to load|syntax error|transform error|no test files found|cannot find module.*vitest" w4-2-red-output-clean.txt; then
             echo "RED is invalid because the runner or test module failed."
             exit 1
           fi
 
-          echo "Correct RED established: all 16 W4.2 tests executed and failed on absent behaviour."
+          echo "Correct RED established: exactly 16 W4.2 tests executed, all 16 failed, and none passed or skipped."
 
       - name: Upload RED output
         uses: actions/upload-artifact@v4
         with:
           name: alp-w4-2-red-output
-          path: w4-2-red-output.txt
+          path: |
+            w4-2-red-output.txt
+            w4-2-red-output-clean.txt
           if-no-files-found: error

--- a/modules/ALP/05-qa-to-red/qa-to-red.md
+++ b/modules/ALP/05-qa-to-red/qa-to-red.md
@@ -6,11 +6,11 @@
 |---|---|
 | Module | ALP — APGI Learning Portal |
 | Stage | 6 — QA-to-Red |
-| Version | 0.2 |
-| Status | Draft — executable RED tests added for prior scopes; W4.2 expansion RED proof still required |
+| Version | 0.3 |
+| Status | W4.2 executable RED filed; branch proof required before build authorization |
 | Repository | APGI-cmy/Training |
 | Canonical Path | modules/ALP/05-qa-to-red/qa-to-red.md |
-| Build Authorized? | No new W4.2 build until executable expansion RED is accepted |
+| Build Authorized? | No new W4.2 build until executable expansion RED is reviewed, accepted and merged |
 | PBFAG Authorized? | No |
 
 ## Purpose
@@ -34,6 +34,7 @@ tests/qa-to-red/alp/assessment-submission.spec.ts
 tests/qa-to-red/alp/certificate.spec.ts
 tests/qa-to-red/alp/security-privacy.spec.ts
 tests/qa-to-red/alp/deployment-cwt.spec.ts
+tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts
 ```
 
 ## QA Domains
@@ -48,6 +49,7 @@ tests/qa-to-red/alp/deployment-cwt.spec.ts
 | Certificates | Eligibility, generation, download, audit |
 | RLS/privacy | Table RLS, cross-learner denial, private files |
 | Deployment/CWT | Build/typecheck/test scripts, evidence, CWT closure |
+| W4.2 enrolment and catalogue | Generic navigation/catalogue, admin authorization, invitations, protected tokens, audit, revoke/reinstate and pending denial |
 
 ## W4 Expansion QA Specification
 
@@ -57,12 +59,14 @@ The discoverable Stage 6 expansion plan is:
 
 It defines:
 
-- QA-ALP-252 through QA-ALP-267 for the next W4.2 catalogue, administrator-invitation and access-management RED suite;
+- QA-ALP-252 through QA-ALP-267 for the W4.2 catalogue, administrator-invitation and access-management RED suite;
 - QA-ALP-268 through QA-ALP-272 as reserved for a later W4.3 payment-status-model cycle;
 - QA-ALP-273 as reserved for the W4.4 provider/security/risk decision gate; and
 - QA-ALP-274 through QA-ALP-276 as reserved for W4.5 sandbox payment and offer-control execution after W4.1-W4.4 acceptance.
 
-Only W4.2 executable RED work is authorized after the governing prebuild merges. Payment execution remains blocked.
+The W4.2 executable suite is filed at `tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts`. The dedicated command is `npm run test:alp:w4-2:red`. The proof workflow is `.github/workflows/alp-w4-2-red-proof.yml`.
+
+Payment execution remains blocked.
 
 ## RED Validity Rule
 
@@ -70,18 +74,17 @@ Valid RED means tests execute and fail because implementation artifacts are miss
 
 ## Stage Gate
 
-Stage 6 expansion is not complete until:
+Stage 6 W4.2 expansion is not complete until:
 
-- applicable executable tests exist;
-- `npm run test:alp:red` executes;
-- failures are confirmed correct RED;
-- `red-proof-report.md` is completed or supplemented for the expansion;
-- QA Catalog alignment is accepted;
-- no implementation has started before RED acceptance; and
-- build remains blocked until the applicable gate passes.
+- QA-ALP-252 through QA-ALP-267 exist as executable tests;
+- `npm run test:alp:w4-2:red` executes;
+- all sixteen tests are present and failures are confirmed correct RED;
+- GOV-ALP-095 records the proof result;
+- no W4.2 implementation has started before RED acceptance; and
+- the build remains blocked until this RED PR is reviewed and merged.
 
 ## Next Artifact
 
 ```text
-modules/ALP/05-qa-to-red/red-proof-report.md
+modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md
 ```

--- a/modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md
+++ b/modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md
@@ -8,7 +8,7 @@
 | Wave | W4.2 manual/admin enrolment and generic catalogue |
 | Evidence Type | Executable RED filing and proof decision |
 | Date | 2026-07-22 |
-| Status | Filed for RED review; W4.2 build remains blocked |
+| Status | Exact branch RED proof passed; filed for review; W4.2 build remains blocked pending merge |
 | Branch | `agent/alp-w4-2-executable-red` |
 | Repository | APGI-cmy/Training |
 
@@ -23,28 +23,11 @@ PR #93 merged the prebuild authority for QA-ALP-252 through QA-ALP-267. That aut
 - Proof workflow: `.github/workflows/alp-w4-2-red-proof.yml`
 - QA range: QA-ALP-252 through QA-ALP-267
 
-The suite covers:
-
-1. generic learner navigation;
-2. multi-course catalogue source;
-3. learner-specific catalogue state and actions;
-4. admin-only authorization;
-5. legacy-route inventory and redirects;
-6. invitation creation;
-7. mandatory reasons;
-8. protected invitation tokens;
-9. invalid/expired/revoked/reused/email-mismatch denial;
-10. idempotent redemption;
-11. invitation lifecycle audit;
-12. batch recipient outcomes;
-13. governed revoke/reinstate evidence;
-14. revoked access denial;
-15. reinstatement audit and access restoration; and
-16. pending access denial.
+The suite covers generic navigation and catalogue, multi-course sourcing, learner-specific state, admin authorization, legacy redirects, invitation creation, mandatory reasons, protected tokens, negative redemption paths, idempotency, lifecycle audit, batch outcomes, revoke/reinstate evidence, revoked denial, reinstatement and pending denial.
 
 ## Correct RED validation
 
-A controlled local structural execution using the repository test helper and the current merged source markers produced:
+A controlled local structural execution produced:
 
 - test files executed: 1;
 - tests executed: 16;
@@ -53,18 +36,24 @@ A controlled local structural execution using the repository test helper and the
 - failure type: assertion failures for absent W4.2 behaviour and artifacts;
 - no syntax, transform, missing-runner or skipped-test failure observed.
 
-The GitHub proof workflow independently requires the exact branch suite to:
+The exact GitHub branch proof independently completed successfully:
 
-- exit non-zero;
-- report all sixteen failures;
-- contain every QA ID from QA-ALP-252 through QA-ALP-267; and
-- contain no runner/setup failure markers.
+| Proof item | Result |
+|---|---|
+| Workflow | `ALP W4.2 RED Proof` |
+| Run ID | `29897844810` |
+| Job | `prove-correct-red` |
+| Job conclusion | Success |
+| Dependency installation | Success |
+| RED execution step | Success |
+| RED artifact upload | Success |
+| Expected interpretation | All sixteen W4.2 tests executed and failed on absent behaviour; workflow converted correct RED into a passing governance check |
+
+The workflow fails if the suite unexpectedly passes, any QA ID from QA-ALP-252 through QA-ALP-267 is absent, the expected sixteen failures are not present, or runner/setup failure markers appear.
 
 ## Governance decision
 
-This PR files executable RED only. It does not authorize or perform W4.2 implementation. Build authorization may be considered only after this PR is reviewed, the branch proof is accepted, and the PR is merged.
-
-After merge, the next separately reviewed build may implement only the approved W4.2 catalogue, admin authorization, invitation/manual enrolment, revoke/reinstate and redirect-inventory scope.
+Correct executable RED is established for the PR branch. This does not authorize W4.2 implementation before review and merge. After this PR merges, a separate W4.2 build branch may implement only the approved catalogue, admin authorization, invitation/manual enrolment, revoke/reinstate and redirect-inventory scope.
 
 ## Explicit non-claims
 

--- a/modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md
+++ b/modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md
@@ -8,7 +8,7 @@
 | Wave | W4.2 manual/admin enrolment and generic catalogue |
 | Evidence Type | Executable RED filing and proof decision |
 | Date | 2026-07-22 |
-| Status | Exact branch RED proof passed; filed for review; W4.2 build remains blocked pending merge |
+| Status | Exact-head RED proof passed; filed for review; W4.2 build remains blocked pending merge |
 | Branch | `agent/alp-w4-2-executable-red` |
 | Repository | APGI-cmy/Training |
 
@@ -27,7 +27,7 @@ The suite covers generic navigation and catalogue, multi-course sourcing, learne
 
 ## Correct RED validation
 
-A controlled local structural execution produced:
+A controlled structural execution produced:
 
 - test files executed: 1;
 - tests executed: 16;
@@ -36,24 +36,26 @@ A controlled local structural execution produced:
 - failure type: assertion failures for absent W4.2 behaviour and artifacts;
 - no syntax, transform, missing-runner or skipped-test failure observed.
 
-The exact GitHub branch proof independently completed successfully:
+The GitHub workflow independently validates the exact current PR head:
 
-| Proof item | Result |
+| Proof item | Required result |
 |---|---|
 | Workflow | `ALP W4.2 RED Proof` |
-| Run ID | `29897844810` |
+| Scope | Current PR head, not a frozen historical run number |
 | Job | `prove-correct-red` |
 | Job conclusion | Success |
 | Dependency installation | Success |
-| RED execution step | Success |
+| Test files | Exactly 1 failed test file out of 1 |
+| Tests | Exactly 16 failed tests out of 16 |
+| Passed/skipped/todo tests | Zero |
+| QA markers | Every ID from QA-ALP-252 through QA-ALP-267 present |
 | RED artifact upload | Success |
-| Expected interpretation | All sixteen W4.2 tests executed and failed on absent behaviour; workflow converted correct RED into a passing governance check |
 
-The workflow fails if the suite unexpectedly passes, any QA ID from QA-ALP-252 through QA-ALP-267 is absent, the expected sixteen failures are not present, or runner/setup failure markers appear.
+The workflow fails if the suite unexpectedly passes, any W4.2 test passes or is skipped/todo, any QA ID is absent, the exact one-file/sixteen-test result is not present, or runner/setup failure markers appear.
 
 ## Governance decision
 
-Correct executable RED is established for the PR branch. This does not authorize W4.2 implementation before review and merge. After this PR merges, a separate W4.2 build branch may implement only the approved catalogue, admin authorization, invitation/manual enrolment, revoke/reinstate and redirect-inventory scope.
+Correct executable RED is established only when the workflow is successful on the current PR head. This does not authorize W4.2 implementation before review and merge. After this PR merges, a separate W4.2 build branch may implement only the approved catalogue, admin authorization, invitation/manual enrolment, revoke/reinstate and redirect-inventory scope.
 
 ## Explicit non-claims
 

--- a/modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md
+++ b/modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md
@@ -1,0 +1,83 @@
+# GOV-ALP-095 - W4.2 Executable QA-to-Red Decision
+
+## Status
+
+| Field | Value |
+|---|---|
+| Module | ALP - APGI Learning Portal |
+| Wave | W4.2 manual/admin enrolment and generic catalogue |
+| Evidence Type | Executable RED filing and proof decision |
+| Date | 2026-07-22 |
+| Status | Filed for RED review; W4.2 build remains blocked |
+| Branch | `agent/alp-w4-2-executable-red` |
+| Repository | APGI-cmy/Training |
+
+## Authority
+
+PR #93 merged the prebuild authority for QA-ALP-252 through QA-ALP-267. That authority requires executable tests and correct RED proof before any W4.2 implementation, live admin-role assignment, invitation write or enrolment-management write.
+
+## Executable suite
+
+- Test file: `tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts`
+- Command: `npm run test:alp:w4-2:red`
+- Proof workflow: `.github/workflows/alp-w4-2-red-proof.yml`
+- QA range: QA-ALP-252 through QA-ALP-267
+
+The suite covers:
+
+1. generic learner navigation;
+2. multi-course catalogue source;
+3. learner-specific catalogue state and actions;
+4. admin-only authorization;
+5. legacy-route inventory and redirects;
+6. invitation creation;
+7. mandatory reasons;
+8. protected invitation tokens;
+9. invalid/expired/revoked/reused/email-mismatch denial;
+10. idempotent redemption;
+11. invitation lifecycle audit;
+12. batch recipient outcomes;
+13. governed revoke/reinstate evidence;
+14. revoked access denial;
+15. reinstatement audit and access restoration; and
+16. pending access denial.
+
+## Correct RED validation
+
+A controlled local structural execution using the repository test helper and the current merged source markers produced:
+
+- test files executed: 1;
+- tests executed: 16;
+- tests failed: 16;
+- runner: Vitest;
+- failure type: assertion failures for absent W4.2 behaviour and artifacts;
+- no syntax, transform, missing-runner or skipped-test failure observed.
+
+The GitHub proof workflow independently requires the exact branch suite to:
+
+- exit non-zero;
+- report all sixteen failures;
+- contain every QA ID from QA-ALP-252 through QA-ALP-267; and
+- contain no runner/setup failure markers.
+
+## Governance decision
+
+This PR files executable RED only. It does not authorize or perform W4.2 implementation. Build authorization may be considered only after this PR is reviewed, the branch proof is accepted, and the PR is merged.
+
+After merge, the next separately reviewed build may implement only the approved W4.2 catalogue, admin authorization, invitation/manual enrolment, revoke/reinstate and redirect-inventory scope.
+
+## Explicit non-claims
+
+This evidence does not claim or perform:
+
+- W4.2 implementation;
+- live `admin` assignment to `johan.ras@apginc.ca`;
+- database migration application;
+- invitation creation or dispatch;
+- enrolment creation, revocation or reinstatement;
+- W4.1 final closure;
+- W4 closure;
+- W4.3, W4.4 or W4.5 start;
+- CODE_PASS, FUNCTIONAL_PASS or CWT_PASS;
+- deployment acceptance; or
+- production readiness.

--- a/modules/ALP/11-build/evidence/index.md
+++ b/modules/ALP/11-build/evidence/index.md
@@ -17,19 +17,23 @@
 
 | Wave | Evidence File | QA Marker(s) | Golden / Negative Path | Environment | PR / Commit | Check Status | Reviewer / Owner | Closure Status | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | governance-artifacts; architecture-inventory | Scaffold path | GitHub / Vercel | PR #71 | Accepted | BC-ALP-CONSOLIDATED-001 | Closed for scaffold scope | No full app delivery claim. |
-| W1 | W1 evidence files | auth; security-privacy | Auth / profile / files | GitHub / Vercel | PR #73-#77 | Accepted | BC-ALP-CONSOLIDATED-001 | Closed for W1 scope | W2 entry authorized by PR #77. |
-| W2 | W2 evidence files | GOV-ALP-078; GOV-ALP-079 | Dashboard / course / unit | GitHub / Vercel / screenshots | PR #78-#79 | Accepted | BC-ALP-CONSOLIDATED-001 | Closed for W2 scope | ALP-CTRL-010 carried forward. |
-| W3 | W3 evidence files | GOV-ALP-080-083 | Progress and completion | GitHub / Vercel / Supabase | PR #80-#84 | Accepted | BC-ALP-CONSOLIDATED-001 | Closed for approved W3 scope | ALP-CTRL-011 closed. |
-| W4 | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-085-decision-enrolment-payments-entry.md` | GOV-ALP-085 | W4 entry and sequencing | GitHub | PR #85 | Merged | BC-ALP-CONSOLIDATED-001 | Entry merged; not closed | Establishes W4.1-W4.5 sequence. |
-| W4.1 | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-086-decision-enrolment-access-gating.md` | GOV-ALP-086; QA-ALP-241-244 | Enrolment gate | GitHub / Supabase | PR #86 | Merged | BC-ALP-CONSOLIDATED-001 | Implementation merged | Live proof followed. |
-| W4.1 | `modules/ALP/11-build/evidence/20260707-W4-GOV-ALP-088-decision-enrolment-db-proof-closure.md` | GOV-ALP-088 | DB/RLS proof | Live Supabase | PR #88 | Merged | BC-ALP-CONSOLIDATED-001 | DB proof closed | No write policies verified. |
+| W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | governance-artifacts; architecture-inventory | Scaffold path | GitHub / Vercel | PR #71 / `48ce32a1974b14487864713af1287ab0379cf4d8` | Accepted before merge | BC-ALP-CONSOLIDATED-001 | Closed for scaffold scope | No full app delivery claim. |
+| W1 | W1 evidence files | auth; security-privacy | Auth / profile / files path | GitHub / Vercel | PR #73-#77 | Accepted before merge | BC-ALP-CONSOLIDATED-001 | Closed for W1 scope | W2 entry authorized by PR #77. |
+| W2 | W2 evidence files | GOV-ALP-078; GOV-ALP-079 | Dashboard / course shell / unit viewer path | GitHub / Vercel / reviewer screenshots | PR #78-#79 | Accepted before merge | BC-ALP-CONSOLIDATED-001 / reviewer proof | Closed for W2 scope | Carries ALP-CTRL-010 forward. |
+| W3 | `modules/ALP/11-build/evidence/20260630-W3-GOV-ALP-080-decision-progress-completion-entry.md` | GOV-ALP-080 | W3 progress/completion entry | GitHub PR evidence | PR #80 | Merged | BC-ALP-CONSOLIDATED-001 | Merged | W3 implementation slice only. |
+| W3 | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-081-decision-progress-proof-fix.md` | GOV-ALP-081 | Progress proof fix | GitHub / reviewer proof | PR #81 | Merged | BC-ALP-CONSOLIDATED-001 | Merged | Visible progress recording fixed. |
+| W3 | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-082-decision-deployed-proof-closure.md` | GOV-ALP-082 | Deployed UI proof | Deployed app | PR #82 | Merged | Reviewer proof | UI proof only | Did not close W3. |
+| W3 | `modules/ALP/11-build/evidence/20260702-W3-GOV-ALP-083-decision-db-progress-closure.md` | GOV-ALP-083; ALP-CTRL-011 | Database-backed progress closure | Live Supabase | PR #83 | Merged | BC-ALP-CONSOLIDATED-001 | Closed for approved W3 scope | Live progress tables verified. |
+| W4 | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-085-decision-enrolment-payments-entry.md` | GOV-ALP-085 | W4 entry and payment sequencing | GitHub PR evidence | PR #85 | Merged | BC-ALP-CONSOLIDATED-001 | Entry merged; not closed | Establishes W4.1-W4.5 sequence. |
+| W4.1 | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-086-decision-enrolment-access-gating.md` | GOV-ALP-086; QA-ALP-241-244 | Enrolment access gating | GitHub / Supabase migration | PR #86 | Merged | BC-ALP-CONSOLIDATED-001 | Implementation merged | Live proof followed. |
+| W4.1 | `modules/ALP/11-build/evidence/20260707-W4-GOV-ALP-087-decision-enrolment-db-proof.md` | GOV-ALP-087 | Table existence | Live Supabase | PR #87 | Merged | BC-ALP-CONSOLIDATED-001 | Superseded by GOV-ALP-088 | Partial DB proof. |
+| W4.1 | `modules/ALP/11-build/evidence/20260707-W4-GOV-ALP-088-decision-enrolment-db-proof-closure.md` | GOV-ALP-088 | RLS/policies/reads/migration proof | Live Supabase | PR #88 | Merged | BC-ALP-CONSOLIDATED-001 | DB proof closed | No write policies verified. |
 | W4.1 | `modules/ALP/11-build/evidence/20260710-W4-GOV-ALP-089-decision-w4-1-final-closure.md` | GOV-ALP-089 | UI proof hold | GitHub / Supabase | PR #89 | Merged | BC-ALP-CONSOLIDATED-001 | Final closure held | Browser proof required. |
-| W4.1 | `modules/ALP/11-build/evidence/20260710-W4-GOV-ALP-091-decision-ui-proof-enabler.md` | GOV-ALP-091; QA-ALP-246-247 | Sign-out/navigation | GitHub / Vercel | PR #90 | Merged | BC-ALP-CONSOLIDATED-001 | Enabler merged | Navigation loop found later. |
-| W4.1 | `modules/ALP/11-build/evidence/20260712-W4-GOV-ALP-092-decision-navigation-proof-prebuild.md` | GOV-ALP-092 | Navigation prebuild | User screenshots / governance | PR #91 | Merged | BC-ALP-CONSOLIDATED-001 | Prebuild merged | Narrow build authorized. |
-| W4.1 | `modules/ALP/11-build/evidence/20260715-W4-GOV-ALP-093-decision-navigation-loop-breaker-build.md` | GOV-ALP-093; QA-ALP-248-251 | Sidebar and denied recovery | GitHub / Vercel / screenshots | PR #92 / `a0c0944a8399c97c90817916f74140c5369daede` | Merged; Vercel passed | Product-owner proof | Partial UI proof accepted; W4.1 open | Enrolled, pending, revoked and unknown proof remain. |
-| W4.2 / W4.3-W4.5 roadmap | `modules/ALP/11-build/evidence/20260721-W4-GOV-ALP-094-decision-enrolment-catalogue-prebuild.md` | QA-ALP-252-267; reserved QA-ALP-268-276 | Catalogue/admin enrolment and payment roadmap | GitHub / schema inspection | PR #93 / `721be18e88d284ffffc4179e71e3dd936b14a319` | Merged; Vercel passed | Product owner / reviewer | Prebuild merged; implementation not started | W4.2 RED next; later payment gates preserved. |
-| W4.2 | `modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md` | QA-ALP-252-267 | Correct RED for absent catalogue/admin invitation/access management | Vitest / GitHub Actions | Current RED PR | Branch proof pending review | Product owner / reviewer | Executable RED filed; build blocked | No application code, migration or live role/enrolment write. |
+| W4.1 | `modules/ALP/11-build/evidence/20260710-W4-GOV-ALP-091-decision-ui-proof-enabler.md` | GOV-ALP-091; QA-ALP-246-247 | Sign-out/navigation clarification | GitHub / Vercel | PR #90 | Merged | BC-ALP-CONSOLIDATED-001 | Enabler merged | Navigation loop found later. |
+| W4.1 | `modules/ALP/11-build/evidence/20260712-W4-GOV-ALP-092-decision-navigation-proof-prebuild.md` | GOV-ALP-092 | Navigation prebuild | User screenshots / governance | PR #91 | Merged | BC-ALP-CONSOLIDATED-001 | Prebuild merged | Narrow loop-breaker authorized. |
+| W4.1 | `modules/ALP/11-build/evidence/20260715-W4-GOV-ALP-093-decision-navigation-loop-breaker-build.md` | GOV-ALP-093; QA-ALP-248-251 | Sidebar, denied-state recovery and not-enrolled path | GitHub / Vercel / user screenshots | PR #92 / `a0c0944a8399c97c90817916f74140c5369daede` | Merged; Vercel passed | Product-owner browser proof | Partial UI proof accepted; W4.1 open | Enrolled, pending, revoked and unknown/error proof remains. |
+| W4.2 / W4.3-W4.5 roadmap | `modules/ALP/11-build/evidence/20260721-W4-GOV-ALP-094-decision-enrolment-catalogue-prebuild.md` | QA-ALP-252-267; reserved QA-ALP-268-276 | Catalogue, admin invitation/access management; payment roadmap gates | GitHub PR evidence / live-schema inspection | PR #93 / `721be18e88d284ffffc4179e71e3dd936b14a319` | Merged; Vercel passed | Product owner / reviewer | Prebuild merged; implementation not started | W4.2 RED is next; W4.3 status model, W4.4 decision and W4.5 execution remain separate later cycles. |
+| W4.2 | `modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md` | QA-ALP-252-267 | Correct RED for absent catalogue/admin invitation/access management | Vitest / GitHub Actions | PR #94 current | Exact-head `ALP W4.2 RED Proof` required successful | Product owner / reviewer | Executable RED filed; build blocked pending merge | No application code, migration or live role/enrolment write. |
 
 ---
 
@@ -39,10 +43,12 @@ Full app delivery: NOT CLAIMED.
 CODE_PASS: NOT CLAIMED.  
 FUNCTIONAL_PASS: NOT CLAIMED.  
 CWT_PASS: NOT CLAIMED.  
+Final content quality acceptance: NOT CLAIMED.  
 Deployment acceptance: NOT CLAIMED.  
 Production readiness: NOT CLAIMED.  
 Live payment readiness: NOT CLAIMED.  
 ALP-CTRL-010: OPEN and carried forward.  
-W4.1: FINAL CLOSURE NOT CLAIMED.  
+W4: IMPLEMENTATION STARTED, but W4 closure is NOT CLAIMED.  
+W4.1: DB proof closed and partial browser proof accepted; FINAL CLOSURE NOT CLAIMED.  
 W4.2: EXECUTABLE RED FILED; IMPLEMENTATION NOT STARTED.  
-W4.3-W4.5: NOT STARTED; PAYMENT EXECUTION NOT AUTHORIZED.
+W4.3-W4.5: ROADMAP ONLY; PAYMENT EXECUTION NOT AUTHORIZED.

--- a/modules/ALP/11-build/evidence/index.md
+++ b/modules/ALP/11-build/evidence/index.md
@@ -6,8 +6,8 @@
 |---|---|
 | Module | ALP - APGI Learning Portal |
 | Artifact | Build Evidence Index |
-| Status | Updated for W4.2 enrolment/catalogue prebuild and W4.3-W4.5 roadmap |
-| Date | 2026-07-21 |
+| Status | Updated for W4.2 executable QA-to-Red filing |
+| Date | 2026-07-22 |
 | Repository | APGI-cmy/Training |
 | Canonical Path | `modules/ALP/11-build/evidence/index.md` |
 
@@ -17,22 +17,19 @@
 
 | Wave | Evidence File | QA Marker(s) | Golden / Negative Path | Environment | PR / Commit | Check Status | Reviewer / Owner | Closure Status | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | governance-artifacts; architecture-inventory | Scaffold path | GitHub / Vercel | PR #71 / `48ce32a1974b14487864713af1287ab0379cf4d8` | Accepted before merge | BC-ALP-CONSOLIDATED-001 | Closed for scaffold scope | No full app delivery claim. |
-| W1 | W1 evidence files | auth; security-privacy | Auth / profile / files path | GitHub / Vercel | PR #73-#77 | Accepted before merge | BC-ALP-CONSOLIDATED-001 | Closed for W1 scope | W2 entry authorized by PR #77. |
-| W2 | W2 evidence files | GOV-ALP-078; GOV-ALP-079 | Dashboard / course shell / unit viewer path | GitHub / Vercel / reviewer screenshots | PR #78-#79 | Accepted before merge | BC-ALP-CONSOLIDATED-001 / reviewer proof | Closed for W2 scope | Carries ALP-CTRL-010 forward. |
-| W3 | `modules/ALP/11-build/evidence/20260630-W3-GOV-ALP-080-decision-progress-completion-entry.md` | GOV-ALP-080 | W3 progress/completion entry | GitHub PR evidence | PR #80 | Merged | BC-ALP-CONSOLIDATED-001 | Merged | W3 implementation slice only. |
-| W3 | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-081-decision-progress-proof-fix.md` | GOV-ALP-081 | Progress proof fix | GitHub / reviewer proof | PR #81 | Merged | BC-ALP-CONSOLIDATED-001 | Merged | Visible progress recording fixed. |
-| W3 | `modules/ALP/11-build/evidence/20260701-W3-GOV-ALP-082-decision-deployed-proof-closure.md` | GOV-ALP-082 | Deployed UI proof | Deployed app | PR #82 | Merged | Reviewer proof | UI proof only | Did not close W3. |
-| W3 | `modules/ALP/11-build/evidence/20260702-W3-GOV-ALP-083-decision-db-progress-closure.md` | GOV-ALP-083; ALP-CTRL-011 | Database-backed progress closure | Live Supabase | PR #83 | Merged | BC-ALP-CONSOLIDATED-001 | Closed for approved W3 scope | Live progress tables verified. |
-| W4 | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-085-decision-enrolment-payments-entry.md` | GOV-ALP-085 | W4 entry and payment sequencing | GitHub PR evidence | PR #85 | Merged | BC-ALP-CONSOLIDATED-001 | Entry merged; not closed | Establishes W4.1-W4.5 sequence. |
-| W4.1 | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-086-decision-enrolment-access-gating.md` | GOV-ALP-086; QA-ALP-241-244 | Enrolment access gating | GitHub / Supabase migration | PR #86 | Merged | BC-ALP-CONSOLIDATED-001 | Implementation merged | Live proof followed. |
-| W4.1 | `modules/ALP/11-build/evidence/20260707-W4-GOV-ALP-087-decision-enrolment-db-proof.md` | GOV-ALP-087 | Table existence | Live Supabase | PR #87 | Merged | BC-ALP-CONSOLIDATED-001 | Superseded by GOV-ALP-088 | Partial DB proof. |
-| W4.1 | `modules/ALP/11-build/evidence/20260707-W4-GOV-ALP-088-decision-enrolment-db-proof-closure.md` | GOV-ALP-088 | RLS/policies/reads/migration proof | Live Supabase | PR #88 | Merged | BC-ALP-CONSOLIDATED-001 | DB proof closed | No write policies verified. |
+| W0 | `modules/ALP/11-build/evidence/w0-foundation-scaffold.md` | governance-artifacts; architecture-inventory | Scaffold path | GitHub / Vercel | PR #71 | Accepted | BC-ALP-CONSOLIDATED-001 | Closed for scaffold scope | No full app delivery claim. |
+| W1 | W1 evidence files | auth; security-privacy | Auth / profile / files | GitHub / Vercel | PR #73-#77 | Accepted | BC-ALP-CONSOLIDATED-001 | Closed for W1 scope | W2 entry authorized by PR #77. |
+| W2 | W2 evidence files | GOV-ALP-078; GOV-ALP-079 | Dashboard / course / unit | GitHub / Vercel / screenshots | PR #78-#79 | Accepted | BC-ALP-CONSOLIDATED-001 | Closed for W2 scope | ALP-CTRL-010 carried forward. |
+| W3 | W3 evidence files | GOV-ALP-080-083 | Progress and completion | GitHub / Vercel / Supabase | PR #80-#84 | Accepted | BC-ALP-CONSOLIDATED-001 | Closed for approved W3 scope | ALP-CTRL-011 closed. |
+| W4 | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-085-decision-enrolment-payments-entry.md` | GOV-ALP-085 | W4 entry and sequencing | GitHub | PR #85 | Merged | BC-ALP-CONSOLIDATED-001 | Entry merged; not closed | Establishes W4.1-W4.5 sequence. |
+| W4.1 | `modules/ALP/11-build/evidence/20260702-W4-GOV-ALP-086-decision-enrolment-access-gating.md` | GOV-ALP-086; QA-ALP-241-244 | Enrolment gate | GitHub / Supabase | PR #86 | Merged | BC-ALP-CONSOLIDATED-001 | Implementation merged | Live proof followed. |
+| W4.1 | `modules/ALP/11-build/evidence/20260707-W4-GOV-ALP-088-decision-enrolment-db-proof-closure.md` | GOV-ALP-088 | DB/RLS proof | Live Supabase | PR #88 | Merged | BC-ALP-CONSOLIDATED-001 | DB proof closed | No write policies verified. |
 | W4.1 | `modules/ALP/11-build/evidence/20260710-W4-GOV-ALP-089-decision-w4-1-final-closure.md` | GOV-ALP-089 | UI proof hold | GitHub / Supabase | PR #89 | Merged | BC-ALP-CONSOLIDATED-001 | Final closure held | Browser proof required. |
-| W4.1 | `modules/ALP/11-build/evidence/20260710-W4-GOV-ALP-091-decision-ui-proof-enabler.md` | GOV-ALP-091; QA-ALP-246-247 | Sign-out/navigation clarification | GitHub / Vercel | PR #90 | Merged | BC-ALP-CONSOLIDATED-001 | Enabler merged | Navigation loop found later. |
-| W4.1 | `modules/ALP/11-build/evidence/20260712-W4-GOV-ALP-092-decision-navigation-proof-prebuild.md` | GOV-ALP-092 | Navigation prebuild | User screenshots / governance | PR #91 | Merged | BC-ALP-CONSOLIDATED-001 | Prebuild merged | Narrow loop-breaker authorized. |
-| W4.1 | `modules/ALP/11-build/evidence/20260715-W4-GOV-ALP-093-decision-navigation-loop-breaker-build.md` | GOV-ALP-093; QA-ALP-248-251 | Sidebar, denied-state recovery and not-enrolled path | GitHub / Vercel / user screenshots | PR #92 / `a0c0944a8399c97c90817916f74140c5369daede` | Merged; Vercel passed | Product-owner browser proof | Partial UI proof accepted; W4.1 open | Enrolled, pending, revoked and unknown/error proof remains. |
-| W4.2 / W4.3-W4.5 roadmap | `modules/ALP/11-build/evidence/20260721-W4-GOV-ALP-094-decision-enrolment-catalogue-prebuild.md` | QA-ALP-252-267; reserved QA-ALP-268-276 | Catalogue, admin invitation/access management; payment roadmap gates | GitHub PR evidence / live-schema inspection | PR #93 current | Pending review | Product owner / reviewer | Prebuild filed; implementation not started | W4.2 RED is next; W4.3 status model, W4.4 decision and W4.5 execution remain separate later cycles. |
+| W4.1 | `modules/ALP/11-build/evidence/20260710-W4-GOV-ALP-091-decision-ui-proof-enabler.md` | GOV-ALP-091; QA-ALP-246-247 | Sign-out/navigation | GitHub / Vercel | PR #90 | Merged | BC-ALP-CONSOLIDATED-001 | Enabler merged | Navigation loop found later. |
+| W4.1 | `modules/ALP/11-build/evidence/20260712-W4-GOV-ALP-092-decision-navigation-proof-prebuild.md` | GOV-ALP-092 | Navigation prebuild | User screenshots / governance | PR #91 | Merged | BC-ALP-CONSOLIDATED-001 | Prebuild merged | Narrow build authorized. |
+| W4.1 | `modules/ALP/11-build/evidence/20260715-W4-GOV-ALP-093-decision-navigation-loop-breaker-build.md` | GOV-ALP-093; QA-ALP-248-251 | Sidebar and denied recovery | GitHub / Vercel / screenshots | PR #92 / `a0c0944a8399c97c90817916f74140c5369daede` | Merged; Vercel passed | Product-owner proof | Partial UI proof accepted; W4.1 open | Enrolled, pending, revoked and unknown proof remain. |
+| W4.2 / W4.3-W4.5 roadmap | `modules/ALP/11-build/evidence/20260721-W4-GOV-ALP-094-decision-enrolment-catalogue-prebuild.md` | QA-ALP-252-267; reserved QA-ALP-268-276 | Catalogue/admin enrolment and payment roadmap | GitHub / schema inspection | PR #93 / `721be18e88d284ffffc4179e71e3dd936b14a319` | Merged; Vercel passed | Product owner / reviewer | Prebuild merged; implementation not started | W4.2 RED next; later payment gates preserved. |
+| W4.2 | `modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md` | QA-ALP-252-267 | Correct RED for absent catalogue/admin invitation/access management | Vitest / GitHub Actions | Current RED PR | Branch proof pending review | Product owner / reviewer | Executable RED filed; build blocked | No application code, migration or live role/enrolment write. |
 
 ---
 
@@ -42,12 +39,10 @@ Full app delivery: NOT CLAIMED.
 CODE_PASS: NOT CLAIMED.  
 FUNCTIONAL_PASS: NOT CLAIMED.  
 CWT_PASS: NOT CLAIMED.  
-Final content quality acceptance: NOT CLAIMED.  
 Deployment acceptance: NOT CLAIMED.  
 Production readiness: NOT CLAIMED.  
 Live payment readiness: NOT CLAIMED.  
 ALP-CTRL-010: OPEN and carried forward.  
-W4: IMPLEMENTATION STARTED, but W4 closure is NOT CLAIMED.  
-W4.1: DB proof closed and partial browser proof accepted; FINAL CLOSURE NOT CLAIMED.  
-W4.2: PREBUILD FILED; IMPLEMENTATION NOT STARTED.  
-W4.3-W4.5: ROADMAP ONLY; PAYMENT EXECUTION NOT AUTHORIZED.
+W4.1: FINAL CLOSURE NOT CLAIMED.  
+W4.2: EXECUTABLE RED FILED; IMPLEMENTATION NOT STARTED.  
+W4.3-W4.5: NOT STARTED; PAYMENT EXECUTION NOT AUTHORIZED.

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -81,7 +81,7 @@
 | Executable RED suite | `tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts` |
 | Dedicated RED command | `npm run test:alp:w4-2:red` |
 | Correct-RED workflow | `.github/workflows/alp-w4-2-red-proof.yml` |
-| Exact branch proof | Workflow run `29897844810`; job `prove-correct-red` succeeded |
+| Exact-head proof | The `ALP W4.2 RED Proof` check must succeed on the current PR head; no frozen historical run ID is authoritative |
 | Executable RED evidence | `modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md` |
 | W4.2 implementation | Not started; blocked until PR #94 is reviewed and merged. |
 
@@ -157,7 +157,7 @@ W4.1 DB Proof Closure: MERGED BY PR #88
 W4.1 Navigation Build: MERGED BY PR #92  
 W4.1 Browser Proof: PARTIALLY ACCEPTED; FINAL CLOSURE NOT CLAIMED  
 W4.2 Prebuild: MERGED BY PR #93  
-W4.2 Executable RED: FILED AND EXACT BRANCH PROOF PASSED IN PR #94; MERGE PENDING  
+W4.2 Executable RED: FILED AND EXACT-HEAD PROOF REQUIRED SUCCESSFUL IN PR #94; MERGE PENDING  
 W4.2 Implementation: NOT STARTED / NOT AUTHORIZED BEFORE PR #94 MERGE  
 W4.3 Payment Status Model: NOT STARTED  
 W4.4 Provider Decision: NOT STARTED  
@@ -196,4 +196,4 @@ Production readiness: NOT CLAIMED
 | 4.6 | 2026-07-13 | Filed W4.1 navigation/sidebar prebuild after loop finding. | AI-assisted draft | Merged by PR #91 |
 | 4.7 | 2026-07-15 | Filed W4.1 persistent sidebar and loop-breaker build. | AI-assisted draft | Merged by PR #92 |
 | 4.8 | 2026-07-21 | Filed W4.2 enrolment/catalogue prebuild and preserved W4.3-W4.5 payment gates. | AI-assisted draft | Merged by PR #93 |
-| 4.9 | 2026-07-22 | Filed executable QA-ALP-252 through QA-ALP-267 and exact branch correct-RED proof. | AI-assisted draft | Filed for review in PR #94 |
+| 4.9 | 2026-07-22 | Filed executable QA-ALP-252 through QA-ALP-267 and exact-head correct-RED proof. | AI-assisted draft | Filed for review in PR #94 |

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -2,12 +2,12 @@
 
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
-**Last Updated**: 2026-07-21  
-**Updated By**: GOV-ALP-094 W4.2 enrolment/catalogue prebuild and W4.3-W4.5 payment roadmap  
-> **Classification**: ACTIVE - W4.2 PREBUILD FILED  
+**Last Updated**: 2026-07-22  
+**Updated By**: GOV-ALP-095 W4.2 executable QA-to-Red proof  
+> **Classification**: ACTIVE - W4.2 EXECUTABLE RED FILED  
 > **Repository**: APGI-cmy/Training  
-> **Current Workstream**: Review W4.2 catalogue/admin-enrolment prebuild; preserve W4.3-W4.5 payment gates  
-> **Next Required Action**: Review/merge PR #93; then file and prove executable W4.2 QA-to-Red before any W4.2 build
+> **Current Workstream**: Review W4.2 executable QA-to-Red proof; implementation remains blocked  
+> **Next Required Action**: Review and merge PR #94; only then open a separate W4.2 build branch
 
 ---
 
@@ -19,9 +19,9 @@
 | W1 Closure / W2 Entry | Closed for W1 scope | PR #77 / `f492c8efd8c83cbca49481191315ac2869c62c3b` |
 | W2 Dashboard / Course Shell / Unit Viewer | Closed for W2 scope | PR #79 / `1b2ae564437a90349ccca95138ac430bf680089b` |
 | W3 Progress + Completion | Closed for approved database-backed scope | PR #80-#84 |
-| W4 Enrolment + Payments | Implementation started; not closed | PR #85 entry; W4.1 chain PR #86-#92; GOV-ALP-094 current |
+| W4 Enrolment + Payments | Implementation started; not closed | PR #85 entry; W4.1 chain PR #86-#92; GOV-ALP-094 and GOV-ALP-095 current |
 | W4.1 Access gating | DB proof closed; partial browser proof accepted; final closure pending | PR #88 DB closure; PR #92 merged; product-owner screenshots |
-| W4.2 Manual/admin enrolment | Prebuild filed; implementation not started | GOV-ALP-094 / PR #93 current |
+| W4.2 Manual/admin enrolment | Prebuild merged; executable RED filed and proven; implementation not started | PR #93 merged; GOV-ALP-095 / PR #94 current |
 | W4.3 Payment status model | Roadmap requirements only; not started | GOV-ALP-085 sequence preserved by GOV-ALP-094 |
 | W4.4 Provider integration decision | Not started | Architecture/security/risk decision required before execution |
 | W4.5 Payment execution | Not started and not authorized | Blocked until W4.1-W4.4 accepted |
@@ -68,21 +68,24 @@
 
 ---
 
-## W4.2 Prebuild Filed
+## W4.2 Prebuild and Executable RED
 
-| Prebuild Item | Status / Link |
+| Item | Status / Link |
 |---|---|
 | App Description addendum | `modules/ALP/00-app-description/addenda/20260721-w4-2-w4-5-enrolment-catalogue-payment-roadmap-addendum.md` |
 | UX Workflow addendum | `modules/ALP/01-ux-workflow-wiring/addenda/20260721-w4-2-w4-5-enrolment-catalogue-payment-roadmap-workflows.md` |
 | FRS addendum | `modules/ALP/02-frs/addenda/20260721-w4-2-w4-5-enrolment-catalogue-payment-roadmap-requirements.md` |
 | Requirement Registry addendum | `modules/ALP/REQUIREMENT_REGISTRY_ADDENDA/20260721-w4-2-w4-5-enrolment-catalogue-payment-roadmap-registry.md` |
 | Canonical Stage 6 expansion QA plan | `modules/ALP/05-qa-to-red/addenda/20260721-w4-2-w4-5-enrolment-catalogue-payment-roadmap-qa-plan.md` |
-| Governance evidence | `modules/ALP/11-build/evidence/20260721-W4-GOV-ALP-094-decision-enrolment-catalogue-prebuild.md` |
-| Evidence index | Updated to include GOV-ALP-094 and PR #92 merged posture. |
-| W4.2 implementation | Not started. |
-| Executable W4.2 RED | Required after PR #93 merge and before build. |
+| Prebuild governance | GOV-ALP-094 merged by PR #93 / `721be18e88d284ffffc4179e71e3dd936b14a319` |
+| Executable RED suite | `tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts` |
+| Dedicated RED command | `npm run test:alp:w4-2:red` |
+| Correct-RED workflow | `.github/workflows/alp-w4-2-red-proof.yml` |
+| Exact branch proof | Workflow run `29897844810`; job `prove-correct-red` succeeded |
+| Executable RED evidence | `modules/ALP/11-build/evidence/20260722-W4-GOV-ALP-095-decision-w4-2-executable-red.md` |
+| W4.2 implementation | Not started; blocked until PR #94 is reviewed and merged. |
 
-### W4.2 Authorized scope after RED acceptance
+### W4.2 Authorized scope after RED PR merge
 
 - generic learner sidebar and multi-course catalogue;
 - learner-specific course state and actions;
@@ -115,7 +118,7 @@ Offer-code execution requires separate W4.5 or later commercial authorization an
 | W1 | Auth + Profile + Files | CLOSED FOR W1 SCOPE | PR #73-#77 merged | Accepted | Admin console proof deferred |
 | W2 | Dashboard + Course Shell + Unit Viewer | CLOSED FOR W2 SCOPE | PR #78-#79 merged | Accepted | ALP-CTRL-010 carried forward |
 | W3 | Progress + Completion | CLOSED FOR APPROVED W3 SCOPE | PR #80-#84 merged | Accepted | ALP-CTRL-010 remains open |
-| W4 | Enrolment + Payments | IMPLEMENTATION STARTED | PR #85-#92 merged; PR #93 prebuild current | Vercel passing; W4.2 RED pending | W4.1 final proof pending; W4.2 not built; W4.3-W4.5 not started |
+| W4 | Enrolment + Payments | IMPLEMENTATION STARTED | PR #85-#93 merged; PR #94 RED current | Correct RED passed; build blocked | W4.1 final proof pending; W4.2 not built; W4.3-W4.5 not started |
 | W5 | Assessment Submission | WAITING | No W5 PR | No checks | Requires W4 closure |
 | W6 | AI Evaluation + Human Review | WAITING | No W6 PR | No checks | Requires W5 closure |
 | W7 | Certificates | WAITING | No W7 PR | No checks | Requires W3/W6 closure |
@@ -139,7 +142,7 @@ Offer-code execution requires separate W4.5 or later commercial authorization an
 
 ## Immediate Next Action
 
-Review and merge PR #93 as a prebuild-only PR. After merge, file executable QA-ALP-252 through QA-ALP-267 tests and confirm correct RED. Only then open the W4.2 build branch. Do not assign admin rights or make live enrolment writes before that gate.
+Review and merge PR #94 as the executable W4.2 QA-to-Red proof. No W4.2 implementation, live admin-role assignment, invitation write or enrolment-management write is authorized before that merge. After merge, open a separate W4.2 build PR and build only to QA-ALP-252 through QA-ALP-267 green while preserving regression suites.
 
 ---
 
@@ -153,9 +156,9 @@ W4.1 Implementation: MERGED BY PR #86
 W4.1 DB Proof Closure: MERGED BY PR #88  
 W4.1 Navigation Build: MERGED BY PR #92  
 W4.1 Browser Proof: PARTIALLY ACCEPTED; FINAL CLOSURE NOT CLAIMED  
-W4.2 Prebuild: FILED FOR REVIEW IN PR #93  
-W4.2 Executable RED: NOT YET FILED  
-W4.2 Implementation: NOT STARTED  
+W4.2 Prebuild: MERGED BY PR #93  
+W4.2 Executable RED: FILED AND EXACT BRANCH PROOF PASSED IN PR #94; MERGE PENDING  
+W4.2 Implementation: NOT STARTED / NOT AUTHORIZED BEFORE PR #94 MERGE  
 W4.3 Payment Status Model: NOT STARTED  
 W4.4 Provider Decision: NOT STARTED  
 W4.5 Payment Execution: NOT STARTED / NOT AUTHORIZED  
@@ -192,4 +195,5 @@ Production readiness: NOT CLAIMED
 | 4.5 | 2026-07-10 | Filed W4.1 UI-proof enabler. | AI-assisted draft | Merged by PR #90 |
 | 4.6 | 2026-07-13 | Filed W4.1 navigation/sidebar prebuild after loop finding. | AI-assisted draft | Merged by PR #91 |
 | 4.7 | 2026-07-15 | Filed W4.1 persistent sidebar and loop-breaker build. | AI-assisted draft | Merged by PR #92 |
-| 4.8 | 2026-07-21 | Filed W4.2 enrolment/catalogue prebuild and preserved W4.3-W4.5 payment gates. | AI-assisted draft | Filed for review in PR #93 |
+| 4.8 | 2026-07-21 | Filed W4.2 enrolment/catalogue prebuild and preserved W4.3-W4.5 payment gates. | AI-assisted draft | Merged by PR #93 |
+| 4.9 | 2026-07-22 | Filed executable QA-ALP-252 through QA-ALP-267 and exact branch correct-RED proof. | AI-assisted draft | Filed for review in PR #94 |

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "test:alp:red": "vitest run tests/qa-to-red/alp",
+    "test:alp:w4-2:red": "vitest run tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts",
     "test:alp:red:static": "vitest run tests/qa-to-red/alp/governance-artifacts.spec.ts tests/qa-to-red/alp/architecture-inventory.spec.ts",
     "test:alp:red:integration": "vitest run tests/qa-to-red/alp --exclude tests/qa-to-red/alp/deployment-cwt.spec.ts",
     "test:alp:red:e2e": "vitest run tests/qa-to-red/alp/course-shell.spec.ts tests/qa-to-red/alp/assessment-submission.spec.ts tests/qa-to-red/alp/certificate.spec.ts",

--- a/tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts
+++ b/tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { expectContains, expectPath, read } from "./helpers/project-root";
+
+const invitationMigration = "supabase/migrations/006_alp_admin_invitations.sql";
+const createInvitationAction = "src/server/actions/invitations/create-invitation.ts";
+const acceptInvitationAction = "src/server/actions/invitations/accept-invitation.ts";
+const changeEnrolmentAction = "src/server/actions/enrolments/change-enrolment-status.ts";
+
+describe("ALP W4.2 executable QA-to-Red", () => {
+  it("QA-ALP-252 sidebar uses generic learner navigation", () => {
+    expectContains("src/components/navigation/LearnerSidebar.tsx", "My learning", "QA-ALP-252");
+    expectContains("src/components/navigation/LearnerSidebar.tsx", "Course catalogue", "QA-ALP-252");
+    expectContains("src/components/navigation/LearnerSidebar.tsx", "Administration", "QA-ALP-252");
+    expect(read("src/components/navigation/LearnerSidebar.tsx").includes("vpshr-level-0"), "QA-ALP-252: sidebar must not hard-code one course").toBe(false);
+  });
+
+  it("QA-ALP-253 catalogue source contains at least two published courses", () => {
+    const source = read("src/lib/courses.ts");
+    expect(source.includes("const courses = [vpshrLevel0 as Course]"), "QA-ALP-253: single-course source remains").toBe(false);
+    expect(source.toLowerCase().includes("scannex"), "QA-ALP-253: second published course is not registered").toBe(true);
+  });
+
+  it("QA-ALP-254 signed-in catalogue presents learner-specific states and actions", () => {
+    expectPath("app/(learner)/catalogue/page.tsx", "QA-ALP-254");
+    for (const marker of ["Enrolled", "Pending", "Not enrolled", "Revoked", "Continue course", "Enrol now"]) {
+      expectContains("app/(learner)/catalogue/page.tsx", marker, "QA-ALP-254");
+    }
+  });
+
+  it("QA-ALP-255 administration is role-gated", () => {
+    expectPath("app/(admin)/admin/layout.tsx", "QA-ALP-255");
+    expectPath("src/lib/auth/require-admin.ts", "QA-ALP-255");
+    expectContains("app/(admin)/admin/layout.tsx", "requireAdmin", "QA-ALP-255");
+  });
+
+  it("QA-ALP-256 legacy routes have an inventory and redirect matrix", () => {
+    expectPath("modules/ALP/11-build/evidence/w4-2-legacy-route-redirect-matrix.md", "QA-ALP-256");
+    expectContains("modules/ALP/11-build/evidence/w4-2-legacy-route-redirect-matrix.md", "Retain or redirect", "QA-ALP-256");
+  });
+
+  it("QA-ALP-257 authorized admin can create a course invitation", () => {
+    expectPath("app/(admin)/admin/invitations/page.tsx", "QA-ALP-257");
+    expectPath(createInvitationAction, "QA-ALP-257");
+    for (const marker of ["recipientEmail", "courseId", "basis", "reason", "expiresAt"]) {
+      expectContains(createInvitationAction, marker, "QA-ALP-257");
+    }
+  });
+
+  it("QA-ALP-258 complimentary and external-payment invitations require a reason", () => {
+    expectPath(createInvitationAction, "QA-ALP-258");
+    expectContains(createInvitationAction, "INVITATION_REASON_REQUIRED", "QA-ALP-258");
+    expectContains(createInvitationAction, "reason.trim()", "QA-ALP-258");
+  });
+
+  it("QA-ALP-259 invitation secrets are protected", () => {
+    expectPath(invitationMigration, "QA-ALP-259");
+    expectContains(invitationMigration, "token_hash", "QA-ALP-259");
+    expectContains(createInvitationAction, "createHash", "QA-ALP-259");
+  });
+
+  it("QA-ALP-260 invalid invitation redemption fails closed", () => {
+    expectPath(acceptInvitationAction, "QA-ALP-260");
+    for (const marker of ["recipient_email", "expires_at", "revoked_at", "redeemed_at", "failed"]) {
+      expectContains(acceptInvitationAction, marker, "QA-ALP-260");
+    }
+  });
+
+  it("QA-ALP-261 invitation redemption is idempotent", () => {
+    expectPath(acceptInvitationAction, "QA-ALP-261");
+    expectContains(acceptInvitationAction, "upsert", "QA-ALP-261");
+    expectContains(acceptInvitationAction, "idempot", "QA-ALP-261");
+  });
+
+  it("QA-ALP-262 invitation lifecycle is audited", () => {
+    expectPath(invitationMigration, "QA-ALP-262");
+    expectContains(invitationMigration, "course_invitation_events", "QA-ALP-262");
+    for (const marker of ["created", "sent", "redeemed", "expired", "revoked", "failed"]) {
+      expectContains(invitationMigration, marker, "QA-ALP-262");
+    }
+  });
+
+  it("QA-ALP-263 batch invitations record each recipient outcome", () => {
+    expectPath("src/server/actions/invitations/create-batch-invitations.ts", "QA-ALP-263");
+    expectContains("src/server/actions/invitations/create-batch-invitations.ts", "recipientResults", "QA-ALP-263");
+  });
+
+  it("QA-ALP-264 revoke and reinstate require actor, reason and state evidence", () => {
+    expectPath(changeEnrolmentAction, "QA-ALP-264");
+    for (const marker of ["reason", "actorId", "previousStatus", "nextStatus"]) {
+      expectContains(changeEnrolmentAction, marker, "QA-ALP-264");
+    }
+  });
+
+  it("QA-ALP-265 revoked learners remain denied after governed revocation", () => {
+    expectPath(changeEnrolmentAction, "QA-ALP-265");
+    expectContains(changeEnrolmentAction, "revoked", "QA-ALP-265");
+    expectContains("src/lib/services/enrolments/get-course-access.ts", "revoked", "QA-ALP-265");
+    expectContains("src/lib/services/enrolments/get-course-access.ts", "canAccess: false", "QA-ALP-265");
+  });
+
+  it("QA-ALP-266 governed reinstatement restores access with an audit event", () => {
+    expectPath(changeEnrolmentAction, "QA-ALP-266");
+    expectContains(changeEnrolmentAction, "reinstated", "QA-ALP-266");
+    expectContains(changeEnrolmentAction, "course_enrolment_events", "QA-ALP-266");
+  });
+
+  it("QA-ALP-267 pending enrolment is created without exposing content", () => {
+    expectPath(createInvitationAction, "QA-ALP-267");
+    expectContains(createInvitationAction, "pending", "QA-ALP-267");
+    expectContains("src/lib/services/enrolments/get-course-access.ts", "pending", "QA-ALP-267");
+    expectContains("src/lib/services/enrolments/get-course-access.ts", "canAccess: false", "QA-ALP-267");
+  });
+});


### PR DESCRIPTION
Files the executable W4.2 QA-to-Red gate required after PR #93 and before any W4.2 implementation.

## Scope

- Adds executable QA-ALP-252 through QA-ALP-267 tests.
- Adds `npm run test:alp:w4-2:red`.
- Adds a GitHub proof workflow that succeeds only when exactly 16 tests execute and all 16 fail for the intended absent W4.2 behaviour.
- Updates the canonical Stage 6 QA authority.
- Files GOV-ALP-095 and adds it to the evidence index.
- Normalizes the canonical `BUILD_PROGRESS_TRACKER.md` while preserving the historical evidence roll-up and existing non-claims.

## Correct RED proof

The suite covers generic navigation/catalogue, multi-course source, learner-specific state, admin authorization, legacy redirects, invitation creation, mandatory reasons, protected invitation tokens, negative redemption paths, idempotency, lifecycle audit, batch outcomes, revoke/reinstate controls, revoked denial and pending denial.

The authoritative proof is the successful `ALP W4.2 RED Proof` check on the current PR head. The workflow requires:

- exactly one failed test file out of one;
- exactly 16 failed tests out of 16;
- zero passed, skipped or todo tests;
- every QA ID from QA-ALP-252 through QA-ALP-267;
- successful dependency installation and artifact upload; and
- no runner, syntax, transform or missing-test failure.

Latest reviewed exact head: `0f310793f2fbf792966632a11a7c6a9feb280d75`.

## Scope boundary

This PR makes no application implementation, Supabase migration application, live admin-role assignment, invitation write, enrolment write, payment change or legacy-route deletion.

W4.2 implementation remains blocked until this RED PR is reviewed and merged. W4.1 final closure remains open. W4.3-W4.5 remain unstarted and payment execution remains unauthorized.

## Authorized next step after merge

Open a separate W4.2 build branch and build only to QA-ALP-252 through QA-ALP-267 green while preserving existing regression suites. The controlled `admin` assignment to `johan.ras@apginc.ca` may occur only inside that later implementation/proof cycle.