### PR TITLE
Harden ALP W4.2 invitation migration security

### DIFF
--- a/.github/workflows/alp-w4-2-red-proof.yml
+++ b/.github/workflows/alp-w4-2-red-proof.yml
@@ -7,6 +7,7 @@ on:
       - "src/**"
       - "supabase/migrations/010_alp_admin_invitations.sql"
       - "tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts"
+      - "tests/qa-to-red/alp/w4-2-migration-security.spec.ts"
       - "package.json"
       - ".github/workflows/alp-w4-2-red-proof.yml"
       - "modules/ALP/11-build/evidence/**"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "test:alp:red": "vitest run tests/qa-to-red/alp",
-    "test:alp:w4-2": "vitest run tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts",
+    "test:alp:w4-2": "vitest run tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts tests/qa-to-red/alp/w4-2-migration-security.spec.ts",
     "test:alp:w4-2:red": "vitest run tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts",
     "test:alp:red:static": "vitest run tests/qa-to-red/alp/governance-artifacts.spec.ts tests/qa-to-red/alp/architecture-inventory.spec.ts",
     "test:alp:red:integration": "vitest run tests/qa-to-red/alp --exclude tests/qa-to-red/alp/deployment-cwt.spec.ts",

--- a/src/lib/services/enrolments/get-course-access.ts
+++ b/src/lib/services/enrolments/get-course-access.ts
@@ -18,10 +18,6 @@ interface CourseEnrolmentRow {
   access_revoked_at?: string | null;
 }
 
-interface PendingInvitationRow {
-  id?: string;
-}
-
 function enrolmentHeaders(accessToken: string) {
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
@@ -58,31 +54,29 @@ export function unknownAccessDecision(userId: string, courseId: string): CourseA
 
 async function hasPendingInvitation({
   accessToken,
-  userEmail,
   courseId
 }: {
   accessToken: string;
-  userEmail?: string;
   courseId: string;
 }) {
-  if (!userEmail) return false;
   const headers = enrolmentHeaders(accessToken);
-  const now = new Date().toISOString();
-  const url = getSupabaseRestUrl(
-    `/rest/v1/course_invitations?select=id&recipient_email=ilike.${encodeURIComponent(userEmail.toLowerCase())}&course_id=eq.${encodeURIComponent(courseId)}&status=in.(pending,sent)&revoked_at=is.null&redeemed_at=is.null&expires_at=gt.${encodeURIComponent(now)}&limit=1`
-  );
+  const url = getSupabaseRestUrl("/rest/v1/rpc/alp_has_pending_invitation");
 
   if (!headers || !url) return false;
-  const response = await fetch(url, { method: "GET", headers, cache: "no-store" });
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ p_course_id: courseId }),
+    cache: "no-store"
+  });
   if (!response.ok) return false;
-  const rows = (await response.json().catch(() => [])) as PendingInvitationRow[];
-  return Boolean(rows[0]?.id);
+  return (await response.json().catch(() => false)) === true;
 }
 
 export async function getCourseAccess({
   accessToken,
   userId,
-  userEmail,
+  userEmail: _userEmail,
   courseId
 }: {
   accessToken: string;
@@ -120,7 +114,7 @@ export async function getCourseAccess({
   const enrolment = rows[0];
 
   if (!enrolment?.status) {
-    if (await hasPendingInvitation({ accessToken, userEmail, courseId })) {
+    if (await hasPendingInvitation({ accessToken, courseId })) {
       return {
         courseId,
         userId,

--- a/supabase/migrations/010_alp_admin_invitations.sql
+++ b/supabase/migrations/010_alp_admin_invitations.sql
@@ -1,4 +1,11 @@
 -- ALP W4.2 - governed administrator invitations and access management
+--
+-- Security model:
+-- - invitation and invitation-event DML is service-role-only;
+-- - signed-in recipients receive only a boolean pending-invitation answer through
+--   alp_has_pending_invitation(text), never direct table access;
+-- - invitation-event history is not deleted implicitly with its parent record;
+-- - existing server actions remain the governed validation and audit boundary.
 
 create table if not exists public.course_invitations (
   id uuid primary key default gen_random_uuid(),
@@ -20,7 +27,7 @@ create table if not exists public.course_invitations (
 
 create table if not exists public.course_invitation_events (
   id uuid primary key default gen_random_uuid(),
-  invitation_id uuid not null references public.course_invitations(id) on delete cascade,
+  invitation_id uuid not null references public.course_invitations(id) on delete restrict,
   event_type text not null check (event_type in ('created', 'sent', 'redeemed', 'expired', 'revoked', 'failed')),
   actor_id uuid references auth.users(id),
   occurred_at timestamptz not null default now(),
@@ -34,57 +41,44 @@ create index if not exists idx_course_invitation_events_invitation on public.cou
 alter table public.course_invitations enable row level security;
 alter table public.course_invitation_events enable row level security;
 
-create or replace function public.alp_is_admin()
+-- New tables receive broad API grants by default in Supabase. Remove them
+-- explicitly so neither anonymous nor ordinary authenticated requests can read,
+-- insert, alter or delete invitation/audit rows. Governed server actions use the
+-- service role and therefore remain the only DML path.
+revoke all privileges on table public.course_invitations from public, anon, authenticated;
+revoke all privileges on table public.course_invitation_events from public, anon, authenticated;
+grant all privileges on table public.course_invitations to service_role;
+grant all privileges on table public.course_invitation_events to service_role;
+
+-- Recipients only need to know whether a usable invitation is pending. Returning
+-- a boolean prevents token hashes, reasons, bases, internal metadata and actor
+-- identifiers from becoming client-readable.
+create or replace function public.alp_has_pending_invitation(p_course_id text)
 returns boolean
 language sql
 stable
 security definer
-set search_path = public
+set search_path = ''
 as $$
-  select exists (
-    select 1 from public.user_roles
-    where user_id = auth.uid() and role = 'admin'
-  );
+  select
+    coalesce((select auth.jwt() ->> 'email'), '') <> ''
+    and exists (
+      select 1
+      from public.course_invitations as invitation
+      where invitation.recipient_email = lower(trim(coalesce((select auth.jwt() ->> 'email'), '')))
+        and invitation.course_id = p_course_id
+        and invitation.status in ('pending', 'sent')
+        and invitation.revoked_at is null
+        and invitation.redeemed_at is null
+        and invitation.expires_at > current_timestamp
+    );
 $$;
 
-drop policy if exists course_invitations_admin_all on public.course_invitations;
-create policy course_invitations_admin_all
-on public.course_invitations
-for all
-using (public.alp_is_admin())
-with check (public.alp_is_admin());
+revoke all privileges on function public.alp_has_pending_invitation(text) from public, anon;
+grant execute on function public.alp_has_pending_invitation(text) to authenticated;
 
-drop policy if exists course_invitations_recipient_select on public.course_invitations;
-create policy course_invitations_recipient_select
-on public.course_invitations
-for select
-using (lower(recipient_email) = lower(coalesce(auth.jwt() ->> 'email', '')));
-
-drop policy if exists course_invitation_events_admin_all on public.course_invitation_events;
-create policy course_invitation_events_admin_all
-on public.course_invitation_events
-for all
-using (public.alp_is_admin())
-with check (public.alp_is_admin());
-
-drop policy if exists course_enrolments_admin_insert on public.course_enrolments;
-create policy course_enrolments_admin_insert
-on public.course_enrolments
-for insert
-with check (public.alp_is_admin());
-
-drop policy if exists course_enrolments_admin_update on public.course_enrolments;
-create policy course_enrolments_admin_update
-on public.course_enrolments
-for update
-using (public.alp_is_admin())
-with check (public.alp_is_admin());
-
-drop policy if exists course_enrolment_events_admin_insert on public.course_enrolment_events;
-create policy course_enrolment_events_admin_insert
-on public.course_enrolment_events
-for insert
-with check (public.alp_is_admin());
+-- Harden the shared trigger function used below without changing its behaviour.
+alter function public.set_updated_at() set search_path = '';
 
 drop trigger if exists set_course_invitations_updated_at on public.course_invitations;
 create trigger set_course_invitations_updated_at

--- a/tests/qa-to-red/alp/w4-2-migration-security.spec.ts
+++ b/tests/qa-to-red/alp/w4-2-migration-security.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { read } from "./helpers/project-root";
+
+const migration = read("supabase/migrations/010_alp_admin_invitations.sql");
+const accessService = read("src/lib/services/enrolments/get-course-access.ts");
+
+describe("ALP W4.2 invitation migration security correction", () => {
+  it("keeps invitation tables inaccessible to anonymous and ordinary authenticated API clients", () => {
+    expect(migration).toContain("revoke all privileges on table public.course_invitations from public, anon, authenticated");
+    expect(migration).toContain("revoke all privileges on table public.course_invitation_events from public, anon, authenticated");
+    expect(migration).toContain("grant all privileges on table public.course_invitations to service_role");
+    expect(migration).toContain("grant all privileges on table public.course_invitation_events to service_role");
+  });
+
+  it("does not expose invitation secrets through a recipient table-select policy", () => {
+    expect(migration).not.toContain("course_invitations_recipient_select");
+    expect(migration).not.toContain("for select\nusing (lower(recipient_email)");
+  });
+
+  it("uses a bounded authenticated boolean RPC for pending invitation detection", () => {
+    expect(migration).toContain("create or replace function public.alp_has_pending_invitation");
+    expect(migration).toContain("returns boolean");
+    expect(migration).toContain("set search_path = ''");
+    expect(migration).toContain("revoke all privileges on function public.alp_has_pending_invitation(text) from public, anon");
+    expect(migration).toContain("grant execute on function public.alp_has_pending_invitation(text) to authenticated");
+    expect(accessService).toContain("/rest/v1/rpc/alp_has_pending_invitation");
+    expect(accessService).toContain("JSON.stringify({ p_course_id: courseId })");
+    expect(accessService).not.toContain("/rest/v1/course_invitations?select=id");
+  });
+
+  it("preserves invitation audit history against implicit parent deletion", () => {
+    expect(migration).toContain("references public.course_invitations(id) on delete restrict");
+    expect(migration).not.toContain("references public.course_invitations(id) on delete cascade");
+  });
+
+  it("does not create direct admin ALL policies over invitation or event records", () => {
+    expect(migration).not.toContain("course_invitations_admin_all");
+    expect(migration).not.toContain("course_invitation_events_admin_all");
+  });
+
+  it("hardens the shared updated-at function search path", () => {
+    expect(migration).toContain("alter function public.set_updated_at() set search_path = ''");
+  });
+});


### PR DESCRIPTION
## Purpose

Correct the Batch 1 stop-gate findings identified before applying `010_alp_admin_invitations.sql` to the live ALP Supabase project.

## Security corrections

- removes direct recipient SELECT access to `course_invitations`;
- replaces recipient table reads with a bounded authenticated boolean RPC, `alp_has_pending_invitation(text)`;
- explicitly revokes invitation and invitation-event table privileges from `public`, `anon` and `authenticated`;
- retains service-role-only invitation and audit DML for the existing governed server actions;
- changes invitation-event parent behaviour from `ON DELETE CASCADE` to `ON DELETE RESTRICT`;
- removes direct admin `FOR ALL` RLS policies over invitation and event records;
- fixes function search paths for the new RPC and the shared `set_updated_at()` trigger helper;
- adds executable migration-security regression tests.

## Preserved behaviour

- administrator invitation creation remains available through the existing server action;
- invitation redemption remains available through the existing server action;
- pending invitation catalogue state remains available through the new boolean RPC;
- W4.2 code/build scope and live-proof sequence remain unchanged.

## Explicit non-actions

This PR does not:

- apply migration `010` to Supabase;
- assign an administrator role;
- create invitation or enrolment data;
- begin browser proof;
- authorize payment work;
- close W4.1, W4.2 or W4;
- claim production readiness.

## Resume condition

After this PR is reviewed, checks pass and Johan merges it, the previously authorised four-batch controlled cycle resumes from Batch 1.