### PR TITLE
Repair ALP Batch 3 browser routing and Scannex assets

### DIFF
--- a/.github/workflows/alp-w4-2-red-proof.yml
+++ b/.github/workflows/alp-w4-2-red-proof.yml
@@ -8,6 +8,7 @@ on:
       - "supabase/migrations/010_alp_admin_invitations.sql"
       - "tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts"
       - "tests/qa-to-red/alp/w4-2-migration-security.spec.ts"
+      - "tests/qa-to-red/alp/w4-2-browser-repair.spec.ts"
       - "package.json"
       - ".github/workflows/alp-w4-2-red-proof.yml"
       - "modules/ALP/11-build/evidence/**"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "test:alp:red": "vitest run tests/qa-to-red/alp",
-    "test:alp:w4-2": "vitest run tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts tests/qa-to-red/alp/w4-2-migration-security.spec.ts",
+    "test:alp:w4-2": "vitest run tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts tests/qa-to-red/alp/w4-2-migration-security.spec.ts tests/qa-to-red/alp/w4-2-browser-repair.spec.ts",
     "test:alp:w4-2:red": "vitest run tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts",
     "test:alp:red:static": "vitest run tests/qa-to-red/alp/governance-artifacts.spec.ts tests/qa-to-red/alp/architecture-inventory.spec.ts",
     "test:alp:red:integration": "vitest run tests/qa-to-red/alp --exclude tests/qa-to-red/alp/deployment-cwt.spec.ts",

--- a/src/lib/asset-path.ts
+++ b/src/lib/asset-path.ts
@@ -1,0 +1,14 @@
+function decodeAssetSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+export function encodeAssetPath(path: string): string {
+  return path
+    .split("/")
+    .map((segment, index) => (index === 0 ? segment : encodeURIComponent(decodeAssetSegment(segment))))
+    .join("/");
+}

--- a/src/lib/auth/post-sign-in-destination.ts
+++ b/src/lib/auth/post-sign-in-destination.ts
@@ -1,0 +1,3 @@
+export function getPostSignInDestination(roles: readonly string[]): "/admin" | "/dashboard" {
+  return roles.includes("admin") ? "/admin" : "/dashboard";
+}

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -107,9 +107,17 @@ export function getUnitStaticParams(): { unitSlug: string }[] {
   });
 }
 
+function decodeAssetSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
 export function encodeAssetPath(path: string): string {
   return path
     .split("/")
-    .map((segment, index) => (index === 0 ? segment : encodeURIComponent(segment)))
+    .map((segment, index) => (index === 0 ? segment : encodeURIComponent(decodeAssetSegment(segment))))
     .join("/");
 }

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -1,6 +1,8 @@
 import vpshrLevel0 from "@/data/vpshr-level-0.json";
 import type { Course, LearningUnit } from "@/types/course";
 
+export { encodeAssetPath } from "@/lib/asset-path";
+
 const scannexSourceRoot = "/courses/Scannex%20Training%20Programme";
 
 function scannexUnit(order: number, folder: string, title: string, subtitle: string): LearningUnit {
@@ -105,19 +107,4 @@ export function getUnitStaticParams(): { unitSlug: string }[] {
 
     return params;
   });
-}
-
-function decodeAssetSegment(segment: string): string {
-  try {
-    return decodeURIComponent(segment);
-  } catch {
-    return segment;
-  }
-}
-
-export function encodeAssetPath(path: string): string {
-  return path
-    .split("/")
-    .map((segment, index) => (index === 0 ? segment : encodeURIComponent(decodeAssetSegment(segment))))
-    .join("/");
 }

--- a/src/server/actions/auth/sign-in.ts
+++ b/src/server/actions/auth/sign-in.ts
@@ -1,7 +1,8 @@
 "use server";
 
 import { redirect } from "next/navigation";
-import { signInWithPassword, signOut } from "@/server/auth/session";
+import { getPostSignInDestination } from "@/lib/auth/post-sign-in-destination";
+import { getCurrentSession, getUserRoles, signInWithPassword, signOut } from "@/server/auth/session";
 
 export type SignInState = {
   error?: string;
@@ -21,7 +22,9 @@ export async function signInAction(_state: SignInState, formData: FormData): Pro
     return { error: result.error };
   }
 
-  redirect("/profile");
+  const session = await getCurrentSession();
+  const roles = session ? await getUserRoles(session.accessToken) : [];
+  redirect(getPostSignInDestination(roles));
 }
 
 export async function signOutAction() {

--- a/tests/qa-to-red/alp/w4-2-browser-repair.spec.ts
+++ b/tests/qa-to-red/alp/w4-2-browser-repair.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getPostSignInDestination } from "../../../src/lib/auth/post-sign-in-destination";
+import { encodeAssetPath } from "../../../src/lib/courses";
+
+describe("ALP W4.2 Batch 3 browser repair", () => {
+  it("routes administrators to the administration landing after sign-in", () => {
+    expect(getPostSignInDestination(["admin"])).toBe("/admin");
+    expect(getPostSignInDestination(["learner", "admin"])).toBe("/admin");
+  });
+
+  it("routes signed-in non-administrators to the learner dashboard", () => {
+    expect(getPostSignInDestination([])).toBe("/dashboard");
+    expect(getPostSignInDestination(["learner"])).toBe("/dashboard");
+    expect(getPostSignInDestination(["reviewer"])).toBe("/dashboard");
+  });
+
+  it("encodes raw asset paths exactly once", () => {
+    expect(encodeAssetPath("/courses/Scannex Training Programme/LU 1 - Introduction & The Case for Scannex/index.html"))
+      .toBe("/courses/Scannex%20Training%20Programme/LU%201%20-%20Introduction%20%26%20The%20Case%20for%20Scannex/index.html");
+  });
+
+  it("does not double-encode already encoded Scannex asset paths", () => {
+    const encoded = "/courses/Scannex%20Training%20Programme/LU%201%20-%20Introduction%20%26%20The%20Case%20for%20Scannex/index.html";
+    const result = encodeAssetPath(encoded);
+
+    expect(result).toBe(encoded);
+    expect(result).not.toContain("%2520");
+    expect(result).not.toContain("%2526");
+  });
+});

--- a/tests/qa-to-red/alp/w4-2-browser-repair.spec.ts
+++ b/tests/qa-to-red/alp/w4-2-browser-repair.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getPostSignInDestination } from "../../../src/lib/auth/post-sign-in-destination";
-import { encodeAssetPath } from "../../../src/lib/courses";
+import { encodeAssetPath } from "../../../src/lib/asset-path";
 
 describe("ALP W4.2 Batch 3 browser repair", () => {
   it("routes administrators to the administration landing after sign-in", () => {


### PR DESCRIPTION
## Purpose

Repair the two functional defects found during controlled Batch 3 browser proof against the live ALP deployment.

## Changes

- route administrators to `/admin` immediately after successful sign-in;
- route signed-in non-administrators to `/dashboard` rather than `/profile`;
- preserve server-side role lookup and fail-safe learner routing when no administrator role is present;
- prevent already encoded Scannex asset paths from being encoded a second time;
- add executable regressions for administrator/learner landing destinations and raw/already-encoded Scannex paths;
- include the new regression file in the W4.2 gate and workflow trigger.

## Controlled evidence preserved

The existing live Batch 3 learner state tagged `ALP-BATCH3-20260727` remains in place for post-deployment retest. This PR performs no Supabase data changes.

## Explicit boundaries

This PR does not:

- delete controlled proof data;
- start Batch 4 cleanup;
- change payment scope;
- close W4.2 or W4;
- claim production readiness before exact-head CI, Vercel and browser retest pass.

## Required validation

1. Exact-head typecheck, W4.2 suite, W1/W4.1 regressions and production build.
2. Exact-head Vercel deployment READY.
3. Browser retest:
   - admin sign-in lands on `/admin`;
   - learner sign-in lands on `/dashboard`;
   - enrolled Scannex learner opens LU1 content without a double-encoded 404.