### PR TITLE
W4.2 persistent invitation lifecycle prebuild and QA-to-Red

### DIFF
--- a/modules/ALP/00-app-description/addenda/20260812-w4-2-invitation-lifecycle.md
+++ b/modules/ALP/00-app-description/addenda/20260812-w4-2-invitation-lifecycle.md
@@ -1,0 +1,15 @@
+# App Description Addendum — W4.2 Persistent Invitation Lifecycle
+
+## Purpose
+Turn the merged PR #104 draft-only learner-management experience into one secure, auditable lifecycle: administrator creates a controlled invitation; learner accepts it; learner completes onboarding; the system grants the agreed course enrolment; learner accesses the course.
+
+## In scope
+- Supabase-backed invitation, learner-profile and enrolment lifecycle.
+- One controlled test learner for end-to-end proof.
+- First-login onboarding: explanation of why profile data is needed; required identity/contact profile; optional CV upload.
+- Protected national identity number suitable for later certificate verification.
+- Invitation create, send, accept, expire, revoke and resend, with audit events.
+- CSV/XLSX execution only after validation, duplicate handling and explicit approval.
+
+## Boundaries
+No payment work, assessment, certificate generation, AI capability, or production bulk import is in scope. AI remains a future functional learner-support/career-guidance decision, requiring separately approved requirements, safety, escalation and human-oversight design.

--- a/modules/ALP/01-ux-workflow-wiring/addenda/20260812-w4-2-invitation-lifecycle-workflow.md
+++ b/modules/ALP/01-ux-workflow-wiring/addenda/20260812-w4-2-invitation-lifecycle-workflow.md
@@ -1,0 +1,11 @@
+# UX Workflow — Invitation to Learning Access
+
+1. Admin selects a learner or validated import row, reviews privacy notice and creates an invitation.
+2. System sends a single-use, expiring invitation link and records created/sent audit events.
+3. Learner opens the link; email/token/course eligibility is validated before any account change.
+4. Learner signs in or registers, then is directed to onboarding—not the dashboard.
+5. Onboarding explains that identity/profile information supports verified training records, certificate authentication and learner support. It captures required profile fields and optional CV.
+6. On verified completion, the invitation is redeemed and the agreed enrolment is created idempotently.
+7. Learner lands on My Learning with the enrolled course. Admin can see invitation/enrolment audit status.
+
+Failure paths: invalid/expired/revoked/reused/wrong-email invitations fail closed with a non-sensitive support route; no learner PII or raw token is exposed in URLs beyond the single invitation token.

--- a/modules/ALP/02-frs/addenda/20260812-w4-2-invitation-lifecycle-requirements.md
+++ b/modules/ALP/02-frs/addenda/20260812-w4-2-invitation-lifecycle-requirements.md
@@ -1,0 +1,12 @@
+# Functional Requirements — W4.2 Persistent Invitation Lifecycle
+
+- FRS-IL-001: Admins can create, revoke and resend governed invitations only after role and input validation.
+- FRS-IL-002: Invitations are signed/single-use/expiring and bound to recipient email and course intent.
+- FRS-IL-003: Accepted invitations route learners to mandatory onboarding before learner access.
+- FRS-IL-004: Onboarding explains the purpose of requested profile information and supports save/validation feedback.
+- FRS-IL-005: Profile stores certificate identity fields, including national identity number, under restricted access; it is never placed in URLs/logs.
+- FRS-IL-006: Learners may upload a CV only to protected storage.
+- FRS-IL-007: Redemption creates exactly one applicable enrolment and complete audit trail.
+- FRS-IL-008: Import execution validates all rows, duplicates and partial-failure disposition before any write.
+- FRS-IL-009: Admin and learner views expose status without raw tokens or unmasked identity numbers.
+- FRS-IL-010: AI is excluded from this wave; future learner-support/career guidance must be separately approved.

--- a/modules/ALP/03-trs/addenda/20260812-w4-2-invitation-lifecycle-technical-requirements.md
+++ b/modules/ALP/03-trs/addenda/20260812-w4-2-invitation-lifecycle-technical-requirements.md
@@ -1,0 +1,10 @@
+# Technical Requirements — W4.2 Persistent Invitation Lifecycle
+
+- Supabase migrations define profile extensions, invitation events and constraints; every exposed table has RLS.
+- National identity number is encrypted or otherwise protected at rest, access-controlled, masked by default and audited; no plaintext in browser logs, URLs or routine admin projections.
+- Invitation operations use server-only code/registered Edge Functions, idempotency keys and a non-enumerating error model.
+- Invitation token material is hashed at rest; raw tokens are never stored or logged.
+- CV files use a private Storage bucket with ownership/RLS policies and metadata validation.
+- Create/send/accept/redeem flows are transactional or safely idempotent, with audit events.
+- Table-pathway, schema-to-hook and RLS-audit evidence are mandatory before closure.
+- Tests must include all lifecycle and failure paths, plus an app-wide QA coverage manifest consumable by the App Management Centre.

--- a/modules/ALP/04-architecture/addenda/20260812-w4-2-invitation-lifecycle-architecture.md
+++ b/modules/ALP/04-architecture/addenda/20260812-w4-2-invitation-lifecycle-architecture.md
@@ -1,0 +1,12 @@
+# Architecture — W4.2 Persistent Invitation Lifecycle
+
+Components: Admin Workspace → server-side invitation service → Supabase invitation/profile/enrolment/audit tables → registered email delivery adapter → invitation landing → Auth → onboarding → protected CV Storage → idempotent redemption → My Learning.
+
+Trust boundaries:
+- Browser has only authenticated user session and one-time invitation token.
+- Server/Edge Function validates role, token, email binding and lifecycle state.
+- Service credentials remain server-side.
+- RLS grants learner ownership access and narrowly scoped admin management; national-ID access is separately restricted.
+- URL/content-source branch remains unchanged.
+
+Required evidence: migration review, table-pathway audit, RLS audit, red-to-green QA evidence, preview browser evidence, controlled test-learner proof, independent review.

--- a/modules/ALP/05-qa-to-red/APP_WIDE_QA_COVERAGE_MANIFEST.md
+++ b/modules/ALP/05-qa-to-red/APP_WIDE_QA_COVERAGE_MANIFEST.md
@@ -2,19 +2,19 @@
 
 This is the canonical coverage map for the App Management Centre (AMC). Each row must carry a test reference, latest state, evidence link and monitoring signal before that capability can claim release acceptance.
 
-| Domain | Required end-to-end test | Current state | AMC health signal |
-|---|---|---|---|
-| Auth and role separation | Login, logout, session expiry, admin/learner denial | Partial | auth failure/error rate |
-| Profile and private files | Onboarding, profile edit, protected CV/photo upload | Not built | RLS/storage denials |
-| Catalogue and course shell | Catalogue → enrolled course → unit navigation | Delivered scope | route/render errors |
-| Media and progress | VPSHR/Scannex playback and idempotent progress | Delivered scope | playback/progress failures |
-| Invitation and enrolment | Create → send → accept → onboarding → enrolment → access | RED | lifecycle/audit failure |
-| Bulk intake | Validate → duplicate disposition → governed execution | Draft-only | validation/import failure |
-| Payments | Checkout → webhook → enrolment/refund | Not built | webhook/payment failures |
-| Assessment and AI | Submit → evaluate → human oversight → appeal | Not built; AI deferred | evaluation queue/quality |
-| Certificates | Eligibility → generation → verification/revocation | Not built | generation/verification failure |
-| Admin, reporting and audit | Authorised management/report/export/audit | Partial | admin/RLS/audit gaps |
-| Database security | Migration/table pathway/RLS audit | Per-wave | policy/advisor failures |
-| Deployment/CWT | CI → preview → smoke → production/runbook | Partial | deployment/runtime failures |
+| Domain | Required end-to-end test | Current state | Evidence | AMC health signal |
+|---|---|---|---|---|
+| Auth and role separation | Login, logout, session expiry, admin/learner denial | Partial | TBD | auth failure/error rate |
+| Profile and private files | Onboarding, profile edit, protected CV/photo upload | Not built | TBD | RLS/storage denials |
+| Catalogue and course shell | Catalogue → enrolled course → unit navigation | Delivered scope | TBD | route/render errors |
+| Media and progress | VPSHR/Scannex playback and idempotent progress | Delivered scope | TBD | playback/progress failures |
+| Invitation and enrolment | Create → send → accept → onboarding → enrolment → access | RED | TBD | lifecycle/audit failure |
+| Bulk intake | Validate → duplicate disposition → governed execution | Draft-only | TBD | validation/import failure |
+| Payments | Checkout → webhook → enrolment/refund | Not built | TBD | webhook/payment failures |
+| Assessment and AI | Submit → evaluate → human oversight → appeal | Not built; AI deferred | TBD | evaluation queue/quality |
+| Certificates | Eligibility → generation → verification/revocation | Not built | TBD | generation/verification failure |
+| Admin, reporting and audit | Authorised management/report/export/audit | Partial | TBD | admin/RLS/audit gaps |
+| Database security | Migration/table pathway/RLS audit | Per-wave | TBD | policy/advisor failures |
+| Deployment/CWT | CI → preview → smoke → production/runbook | Partial | TBD | deployment/runtime failures |
 
 Status is intentionally granular: delivered UI, persistent implementation, automated GREEN and production acceptance are separate facts.

--- a/modules/ALP/05-qa-to-red/APP_WIDE_QA_COVERAGE_MANIFEST.md
+++ b/modules/ALP/05-qa-to-red/APP_WIDE_QA_COVERAGE_MANIFEST.md
@@ -1,20 +1,20 @@
 # App-wide QA Coverage Manifest — APGI Learning Portal
 
-This is the canonical coverage map for the App Management Centre (AMC). Each row must carry a test reference, latest state, evidence link and monitoring signal before that capability can claim release acceptance.
+This is the canonical coverage map for the App Management Centre (AMC). Every capability must map to an executable test reference, accountable owner, latest status, acceptance evidence and monitoring signal before release acceptance. “TBD” is an explicit open obligation, never acceptance evidence.
 
-| Domain | Required end-to-end test | Current state | Evidence | AMC health signal |
-|---|---|---|---|---|
-| Auth and role separation | Login, logout, session expiry, admin/learner denial | Partial | TBD | auth failure/error rate |
-| Profile and private files | Onboarding, profile edit, protected CV/photo upload | Not built | TBD | RLS/storage denials |
-| Catalogue and course shell | Catalogue → enrolled course → unit navigation | Delivered scope | TBD | route/render errors |
-| Media and progress | VPSHR/Scannex playback and idempotent progress | Delivered scope | TBD | playback/progress failures |
-| Invitation and enrolment | Create → send → accept → onboarding → enrolment → access | RED | TBD | lifecycle/audit failure |
-| Bulk intake | Validate → duplicate disposition → governed execution | Draft-only | TBD | validation/import failure |
-| Payments | Checkout → webhook → enrolment/refund | Not built | TBD | webhook/payment failures |
-| Assessment and AI | Submit → evaluate → human oversight → appeal | Not built; AI deferred | TBD | evaluation queue/quality |
-| Certificates | Eligibility → generation → verification/revocation | Not built | TBD | generation/verification failure |
-| Admin, reporting and audit | Authorised management/report/export/audit | Partial | TBD | admin/RLS/audit gaps |
-| Database security | Migration/table pathway/RLS audit | Per-wave | TBD | policy/advisor failures |
-| Deployment/CWT | CI → preview → smoke → production/runbook | Partial | TBD | deployment/runtime failures |
+| Domain | Required end-to-end test | Test reference | Owner | Current state | Evidence | Monitoring signal |
+|---|---|---|---|---|---|---|
+| Auth and role separation | Login, logout, session expiry, admin/learner denial | W1 auth regression suite | Auth/QA | Partial | Existing W1 evidence; expiry test TBD | auth failure/error rate |
+| Profile and private files | Onboarding, profile edit, protected CV/photo upload | QA-IL-006..008 | Data/QA | RED | RED baseline required | RLS/storage denials |
+| Catalogue and course shell | Catalogue → enrolled course → unit navigation | Batch 3 + W2 regression | Product/QA | Delivered scope | PR #102 production smoke | route/render errors |
+| Media and progress | VPSHR/Scannex playback and idempotent progress | W3 regression | Product/QA | Delivered scope | PR #102 production smoke | playback/progress failures |
+| Invitation and enrolment | Create → send → accept → onboarding → enrolment → access | QA-IL-001..009 | Data/QA | RED | RED baseline required | lifecycle/audit failure |
+| Bulk intake | Validate → duplicate disposition → governed execution | QA-IL-010 | Data/QA | Draft-only | PR #104 no-write smoke | validation/import failure |
+| Payments | Checkout → webhook → enrolment/refund | W4.3–W4.5 QA TBD | Payments/QA | Not built | TBD | webhook/payment failures |
+| Assessment and AI | Submit → evaluate → human oversight → appeal | W5–W6 QA TBD | Learning/QA | Not built; AI deferred | TBD | evaluation queue/quality |
+| Certificates | Eligibility → generation → verification/revocation | W7 QA TBD | Certificates/QA | Not built | TBD | generation/verification failure |
+| Admin, reporting and audit | Authorised management/report/export/audit | W4 admin + QA-IL-009 | Admin/QA | Partial | PR #104 / lifecycle RED | admin/RLS/audit gaps |
+| Database security | Migration/table pathway/RLS audit | per-wave schema/RLS tests | Data/QA | Per-wave | Required before DB closure | policy/advisor failures |
+| Deployment/CWT | CI → preview → smoke → production/runbook | deployment/CWT suite TBD | Release/QA | Partial | PR #102 production smoke | deployment/runtime failures |
 
 Status is intentionally granular: delivered UI, persistent implementation, automated GREEN and production acceptance are separate facts.

--- a/modules/ALP/05-qa-to-red/APP_WIDE_QA_COVERAGE_MANIFEST.md
+++ b/modules/ALP/05-qa-to-red/APP_WIDE_QA_COVERAGE_MANIFEST.md
@@ -1,0 +1,20 @@
+# App-wide QA Coverage Manifest — APGI Learning Portal
+
+This is the canonical coverage map for the App Management Centre (AMC). Each row must carry a test reference, latest state, evidence link and monitoring signal before that capability can claim release acceptance.
+
+| Domain | Required end-to-end test | Current state | AMC health signal |
+|---|---|---|---|
+| Auth and role separation | Login, logout, session expiry, admin/learner denial | Partial | auth failure/error rate |
+| Profile and private files | Onboarding, profile edit, protected CV/photo upload | Not built | RLS/storage denials |
+| Catalogue and course shell | Catalogue → enrolled course → unit navigation | Delivered scope | route/render errors |
+| Media and progress | VPSHR/Scannex playback and idempotent progress | Delivered scope | playback/progress failures |
+| Invitation and enrolment | Create → send → accept → onboarding → enrolment → access | RED | lifecycle/audit failure |
+| Bulk intake | Validate → duplicate disposition → governed execution | Draft-only | validation/import failure |
+| Payments | Checkout → webhook → enrolment/refund | Not built | webhook/payment failures |
+| Assessment and AI | Submit → evaluate → human oversight → appeal | Not built; AI deferred | evaluation queue/quality |
+| Certificates | Eligibility → generation → verification/revocation | Not built | generation/verification failure |
+| Admin, reporting and audit | Authorised management/report/export/audit | Partial | admin/RLS/audit gaps |
+| Database security | Migration/table pathway/RLS audit | Per-wave | policy/advisor failures |
+| Deployment/CWT | CI → preview → smoke → production/runbook | Partial | deployment/runtime failures |
+
+Status is intentionally granular: delivered UI, persistent implementation, automated GREEN and production acceptance are separate facts.

--- a/modules/ALP/05-qa-to-red/addenda/20260812-w4-2-invitation-lifecycle-qa-plan.md
+++ b/modules/ALP/05-qa-to-red/addenda/20260812-w4-2-invitation-lifecycle-qa-plan.md
@@ -1,0 +1,17 @@
+# QA-to-Red Plan — W4.2 Persistent Invitation Lifecycle
+
+## Lifecycle RED cases
+- QA-IL-001 admin role required for create/revoke/resend.
+- QA-IL-002 create records only a hashed token, expiry, recipient/course intent and audit event.
+- QA-IL-003 send is idempotent and delivery failures are observable.
+- QA-IL-004 valid acceptance routes to onboarding, never directly to course/dashboard.
+- QA-IL-005 expired/revoked/reused/wrong-email/wrong-course tokens fail closed.
+- QA-IL-006 onboarding requires approved profile fields and shows the reason for collection.
+- QA-IL-007 national ID is masked/restricted/not logged or URL-exposed.
+- QA-IL-008 CV upload is private, validated and accessible only by owner/admin policy.
+- QA-IL-009 redemption creates one enrolment exactly once and audit events.
+- QA-IL-010 bulk import validates schema/duplicates and supports safe all-or-dispositioned execution.
+- QA-IL-011 app-wide coverage manifest maps every approved capability to RED/GREEN test, owner, evidence and monitoring signal.
+
+## App-wide QA coverage
+The manifest must cover auth, profile/files, catalogue/course shell, progress, enrolment/invitation, payments, assessments/AI, certificates, admin/reporting/audit, storage/RLS and deployment/CWT. No capability may be marked complete merely because a UI exists.

--- a/modules/ALP/07-implementation-plan/addenda/20260812-w4-2-invitation-lifecycle-implementation-plan.md
+++ b/modules/ALP/07-implementation-plan/addenda/20260812-w4-2-invitation-lifecycle-implementation-plan.md
@@ -1,0 +1,14 @@
+# Implementation Plan — W4.2 Persistent Invitation Lifecycle
+
+1. Approve this prebuild stack and produce the app-wide QA coverage manifest.
+2. Inspect live Supabase schema, auth and RLS; create schema-to-hook/table-pathway/RLS RED evidence.
+3. Create lifecycle-specific executable QA-to-Red tests and prove correct RED.
+4. Obtain builder appointment for the frozen scope.
+5. Implement migrations, RLS, private CV storage and registered server/Edge Functions.
+6. Implement admin creation/send/revoke/resend, invitation acceptance and mandatory onboarding.
+7. Implement idempotent redemption/enrolment and audit views.
+8. Build lifecycle tests to green; run regression, typecheck, build and security checks.
+9. Use one agreed test learner for preview proof: invite → accept → onboarding/profile/CV → enrolment → learner access.
+10. Independent review, exact-head CI/preview evidence and final merge decision.
+
+AI is explicitly deferred.

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -2,12 +2,12 @@
 
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
-**Last Updated**: 2026-08-12
+**Last Updated**: 2026-08-12 (Invitation Lifecycle prebuild)
 **Updated By**: PR #104 merge reconciliation and product-owner authenticated smoke evidence
 > **Classification**: ACTIVE — BATCH 3 STABILISATION RELEASED; W4.2 LEARNER MANAGEMENT EXPERIENCE MERGED (DRAFT-ONLY)
 > **Repository**: APGI-cmy/Training  
-> **Current Workstream**: W4.2 Learner Management Experience (LMX): safe admin learner directory, staged invitation/import UX and administrator full-page course preview
-> **Next Required Action**: Authorise and design the Supabase-backed invitation, profile and enrolment execution lifecycle, including a controlled test invitation. No production write is authorised by the merged W4.2 UI slice.
+> **Current Workstream**: W4.2 Persistent Invitation Lifecycle: Supabase-backed invitation → onboarding → enrolment → learner access
+> **Next Required Action**: Execute and accept correct QA-to-Red for the frozen invitation lifecycle, then appoint a builder. No implementation, database migration, provider configuration or invitation send is authorised yet.
 
 ---
 
@@ -28,6 +28,10 @@
 | Batch 3 Lane A | Released stabilisation scope; production Git deployment smoke-tested | PR #102 merged at `312e551`; 2026-08 production reconciliation |
 | Invitation delivery preflight | CS2 authorised as separate no-send lane | No provider, secret or send implementation authorised |
 | W4.2 Learner Management Experience | Merged; safe draft/read-only workflow accepted | PR #104 merged a58579f; exact-head CI/Vercel PASS and authenticated no-write smoke |
+
+### W4.2 Persistent Invitation Lifecycle — prebuild filed 2026-08-12
+
+A complete prebuild set has been filed on `agent/w4-2-invitation-lifecycle-prebuild`: App Description, UX workflow, FRS, TRS, architecture, requirement registry, QA-to-Red plan, implementation plan and AMC-consumable app-wide QA coverage manifest. Executable lifecycle QA-to-Red exists at `tests/qa-to-red/alp/w4-2-invitation-lifecycle-red.spec.ts` and must now demonstrate correct RED against the merged baseline. AI is explicitly deferred pending a separate, purpose-led learner-support/career-guidance decision.
 
 ### PR #104 merge reconciliation — W4.2 Learner Management Experience
 

--- a/modules/ALP/REQUIREMENT_REGISTRY_ADDENDA/20260812-w4-2-invitation-lifecycle-registry.md
+++ b/modules/ALP/REQUIREMENT_REGISTRY_ADDENDA/20260812-w4-2-invitation-lifecycle-registry.md
@@ -1,0 +1,10 @@
+# Requirement Registry Addendum — W4.2 Persistent Invitation Lifecycle
+
+| ID | Requirement | Verification |
+|---|---|---|
+| IL-01 | Invite → accept → onboarding → enrolment → access works for one controlled learner | QA-IL-001..009 + browser proof |
+| IL-02 | Profile/CV and national ID are privacy-protected | RLS/storage/security tests |
+| IL-03 | Lifecycle is auditable and idempotent | DB/integration tests + audit evidence |
+| IL-04 | Bulk execution is validated and governed | QA-IL-010 |
+| IL-05 | Whole-app requirements map to test/evidence/monitoring | QA-IL-011 manifest |
+| IL-06 | AI excluded pending purpose-led approval | architecture/plan review |

--- a/tests/qa-to-red/alp/w4-2-invitation-lifecycle-red.spec.ts
+++ b/tests/qa-to-red/alp/w4-2-invitation-lifecycle-red.spec.ts
@@ -3,8 +3,8 @@ import { expectPath, read } from "./helpers/project-root";
 
 describe("ALP W4.2 persistent invitation lifecycle — RED", () => {
   it("QA-IL-001 exposes only an authorised server-side invitation lifecycle", () => {
-    expectPath("src/lib/services/invitations/create-invitation.ts", "QA-IL-001");
-    expect(read("src/lib/services/invitations/create-invitation.ts")).toContain("requireAdmin");
+    expectPath("src/server/actions/invitations/create-invitation.ts", "QA-IL-001");
+    expect(read("src/server/actions/invitations/create-invitation.ts")).toContain("requireAdmin");
   });
   it("QA-IL-004 routes a valid accepted invitation to mandatory onboarding", () => {
     expectPath("app/invitations/[token]/page.tsx", "QA-IL-004");

--- a/tests/qa-to-red/alp/w4-2-invitation-lifecycle-red.spec.ts
+++ b/tests/qa-to-red/alp/w4-2-invitation-lifecycle-red.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { expectPath, read } from "./helpers/project-root";
+
+describe("ALP W4.2 persistent invitation lifecycle — RED", () => {
+  it("QA-IL-001 exposes only an authorised server-side invitation lifecycle", () => {
+    expectPath("src/lib/services/invitations/create-invitation.ts", "QA-IL-001");
+    expect(read("src/lib/services/invitations/create-invitation.ts")).toContain("requireAdmin");
+  });
+  it("QA-IL-004 routes a valid accepted invitation to mandatory onboarding", () => {
+    expectPath("app/invitations/[token]/page.tsx", "QA-IL-004");
+    expect(read("app/invitations/[token]/page.tsx")).toContain("/onboarding");
+  });
+  it("QA-IL-007 protects national identity numbers and CV storage", () => {
+    expectPath("supabase/migrations", "QA-IL-007");
+    expectPath("src/lib/services/profile", "QA-IL-007");
+  });
+  it("QA-IL-009 creates an idempotent enrolment and audit event on redemption", () => {
+    expectPath("src/lib/services/invitations/redeem-invitation.ts", "QA-IL-009");
+    expect(read("src/lib/services/invitations/redeem-invitation.ts")).toContain("idempot");
+  });
+  it("QA-IL-011 provides the AMC-consumable app-wide QA coverage manifest", () => {
+    expectPath("modules/ALP/05-qa-to-red/APP_WIDE_QA_COVERAGE_MANIFEST.md", "QA-IL-011");
+  });
+});

--- a/tests/qa-to-red/alp/w4-2-invitation-lifecycle-red.spec.ts
+++ b/tests/qa-to-red/alp/w4-2-invitation-lifecycle-red.spec.ts
@@ -1,24 +1,71 @@
 import { describe, expect, it } from "vitest";
 import { expectPath, read } from "./helpers/project-root";
 
+const createInvitation = "src/server/actions/invitations/create-invitation.ts";
+const acceptInvitation = "app/(learner)/invitations/[token]/page.tsx";
+const lifecycleService = "src/server/actions/invitations/redeem-invitation.ts";
+const profileService = "src/lib/services/profile/complete-onboarding.ts";
+const lifecycleMigration = "supabase/migrations/011_w4_2_persistent_invitation_lifecycle.sql";
+const storagePolicy = "supabase/migrations/012_w4_2_profile_cv_storage_policies.sql";
+
 describe("ALP W4.2 persistent invitation lifecycle — RED", () => {
-  it("QA-IL-001 exposes only an authorised server-side invitation lifecycle", () => {
-    expectPath("src/server/actions/invitations/create-invitation.ts", "QA-IL-001");
-    expect(read("src/server/actions/invitations/create-invitation.ts")).toContain("requireAdmin");
+  it("QA-IL-001 restricts create/revoke/resend to administrators", () => {
+    expectPath(createInvitation, "QA-IL-001");
+    const source = read(createInvitation);
+    for (const marker of ["requireAdmin", "createInvitation", "revokeInvitation", "resendInvitation"]) expect(source).toContain(marker);
   });
-  it("QA-IL-004 routes a valid accepted invitation to mandatory onboarding", () => {
-    expectPath("app/invitations/[token]/page.tsx", "QA-IL-004");
-    expect(read("app/invitations/[token]/page.tsx")).toContain("/onboarding");
+  it("QA-IL-002 hashes tokens, binds intent and records creation audit evidence", () => {
+    expectPath(lifecycleMigration, "QA-IL-002");
+    const source = read(lifecycleMigration);
+    for (const marker of ["token_hash", "recipient_email", "course_id", "expires_at", "invitation_created"]) expect(source).toContain(marker);
+    expect(source).not.toContain("raw_token");
   });
-  it("QA-IL-007 protects national identity numbers and CV storage", () => {
-    expectPath("supabase/migrations", "QA-IL-007");
-    expectPath("src/lib/services/profile", "QA-IL-007");
+  it("QA-IL-003 makes send idempotent and delivery failure observable", () => {
+    expectPath(createInvitation, "QA-IL-003");
+    const source = read(createInvitation);
+    for (const marker of ["idempotency", "invitation_sent", "delivery_failed"]) expect(source).toContain(marker);
   });
-  it("QA-IL-009 creates an idempotent enrolment and audit event on redemption", () => {
-    expectPath("src/lib/services/invitations/redeem-invitation.ts", "QA-IL-009");
-    expect(read("src/lib/services/invitations/redeem-invitation.ts")).toContain("idempot");
+  it("QA-IL-004 redirects accepted invitations from the existing grouped route to onboarding", () => {
+    expectPath(acceptInvitation, "QA-IL-004");
+    expect(read(acceptInvitation)).toContain("/onboarding");
+  });
+  it("QA-IL-005 fails closed for expired, revoked, reused and wrong-recipient invitations", () => {
+    expectPath(acceptInvitation, "QA-IL-005");
+    const source = read(acceptInvitation);
+    for (const marker of ["expired", "revoked", "redeemed", "recipient_email"]) expect(source).toContain(marker);
+  });
+  it("QA-IL-006 explains data collection and validates onboarding before access", () => {
+    expectPath(profileService, "QA-IL-006");
+    const source = read(profileService);
+    for (const marker of ["certificate", "learner support", "national_identity_number", "validate"]) expect(source).toContain(marker);
+  });
+  it("QA-IL-007 enforces restricted national-ID handling and private CV storage", () => {
+    expectPath(lifecycleMigration, "QA-IL-007");
+    expectPath(storagePolicy, "QA-IL-007");
+    const migration = read(lifecycleMigration);
+    const storage = read(storagePolicy);
+    for (const marker of ["national_identity", "encrypted", "mask", "ENABLE ROW LEVEL SECURITY", "audit"]) expect(migration).toContain(marker);
+    for (const marker of ["cv", "private", "storage.objects", "auth.uid()", "metadata"]) expect(storage).toContain(marker);
+    expect(migration).not.toContain("national_identity_number text");
+  });
+  it("QA-IL-008 validates private CV upload ownership and file metadata", () => {
+    expectPath(storagePolicy, "QA-IL-008");
+    const source = read(storagePolicy);
+    for (const marker of ["INSERT", "SELECT", "owner_id", "content_type", "size"]) expect(source).toContain(marker);
+  });
+  it("QA-IL-009 redeems idempotently into one enrolment and audit trail", () => {
+    expectPath(lifecycleService, "QA-IL-009");
+    const source = read(lifecycleService);
+    for (const marker of ["idempot", "course_enrolments", "invitation_redeemed", "audit"]) expect(source).toContain(marker);
+  });
+  it("QA-IL-010 validates import rows and duplicate disposition before execution", () => {
+    expectPath("src/server/actions/invitations/execute-import.ts", "QA-IL-010");
+    const source = read("src/server/actions/invitations/execute-import.ts");
+    for (const marker of ["duplicate", "validate", "disposition", "idempotency"]) expect(source).toContain(marker);
   });
   it("QA-IL-011 provides the AMC-consumable app-wide QA coverage manifest", () => {
-    expectPath("modules/ALP/05-qa-to-red/APP_WIDE_QA_COVERAGE_MANIFEST.md", "QA-IL-011");
+    const manifest = "modules/ALP/05-qa-to-red/APP_WIDE_QA_COVERAGE_MANIFEST.md";
+    expectPath(manifest, "QA-IL-011");
+    for (const marker of ["Test reference", "Owner", "Evidence", "Monitoring signal"]) expect(read(manifest)).toContain(marker);
   });
 });


### PR DESCRIPTION
## Purpose
Files the governed prebuild for the next W4.2 persistent lifecycle: invitation → onboarding → enrolment → learner access.

## Included
- aligned app description, workflow, FRS, TRS, architecture, registry and implementation plan;
- executable lifecycle QA-to-Red, intentionally RED against the current merged baseline;
- app-wide QA coverage manifest for AMC health monitoring;
- tracker reconciliation.

## Boundaries
No product implementation, Supabase migration, RLS change, Storage bucket, invitation/email send, enrolment write, payment work or AI integration. AI is explicitly deferred for separate functional-purpose approval.

## Next gate
Run and accept correct RED, then appoint a builder for the frozen scope.