### PR TITLE
Accept W4.2 persistent invitation lifecycle correct RED baseline

### DIFF
--- a/.agent-admin/evidence/rls-audit/w4-2-20260812.md
+++ b/.agent-admin/evidence/rls-audit/w4-2-20260812.md
@@ -1,0 +1,25 @@
+# RLS and Security RED Evidence — W4.2 Persistent Invitation Lifecycle
+
+Date: 2026-08-12  
+Inspection method: read-only metadata queries and Supabase Security Advisor.
+
+## Baseline
+
+- Existing private Storage bucket: `alp-private-files`; public access is disabled.
+- Existing profile, file metadata, enrolment and storage-object policies are present.
+- `course_invitations` and `course_invitation_events` have RLS enabled but no policies. This is an explicit build blocker, not an accepted configuration.
+- Security Advisor reports publicly executable SECURITY DEFINER functions including audit/profile/role helpers; lifecycle work must review, narrow or revoke execution explicitly.
+- Leaked-password protection is disabled. Enable it before live invitation-registration testing.
+- Auth logs also report deprecated GoTrue group configuration. Replace it with the supported role model before closure.
+
+## Required RLS acceptance
+
+1. Every new/changed table has RLS enabled and role-specific SELECT/INSERT/UPDATE/DELETE policies.
+2. Invitation rows/events are unreadable to unauthorised users; raw token material is never stored.
+3. Learners can access only their own profile/files/enrolments; admins have narrowly scoped management access.
+4. National identity numbers are protected at rest, masked in routine projections, excluded from logs/URLs and access-audited.
+5. CV files remain private; object paths and metadata are ownership-bound with validated type/size.
+6. SECURITY DEFINER functions have safe search paths and explicit EXECUTE grants, or use SECURITY INVOKER.
+7. Supabase advisors are re-run and all lifecycle-relevant warnings are resolved or formally risk-accepted by the product owner.
+
+No RLS policy, function or Auth setting was changed in this phase.

--- a/.agent-admin/evidence/schema-to-hook/w4-2-20260812.md
+++ b/.agent-admin/evidence/schema-to-hook/w4-2-20260812.md
@@ -1,0 +1,16 @@
+# Schema-to-Hook RED Evidence — W4.2 Persistent Invitation Lifecycle
+
+Date: 2026-08-12  
+CI baseline: [ALP Invitation Lifecycle Correct RED run 31611852576](https://github.com/APGI-cmy/Training/actions/runs/31611852576) — PASS (expected RED reproduced)
+
+| Data concern | Current live schema/hook | Required build-to-Green change | Verification |
+|---|---|---|---|
+| Invitation token | `course_invitations.token_hash` exists; creation action hashes token | Add lifecycle constraints/idempotency/send state; raw token never stored | QA-IL-002,003 |
+| Invitation acceptance | Existing grouped route calls acceptance then directs to `/learn/:courseId` | Validate lifecycle state and direct valid acceptance to onboarding | QA-IL-004,005 |
+| Learner profile | `profiles` has identity/name/contact basics but no national identity field/onboarding completion | Add protected identity storage and completion contract | QA-IL-006,007 |
+| CV file | private bucket and `file_metadata` exist | Bind CV upload to onboarding, validated metadata/ownership | QA-IL-008 |
+| Enrolment | `course_enrolments` and events exist | Atomic/idempotent invitation redemption and audit | QA-IL-009 |
+| Bulk intake | browser-local staging only | Server validation, duplicate disposition and governed execution | QA-IL-010 |
+| Audit | invitation and general audit tables exist | Full lifecycle event vocabulary and immutable audit coverage | QA-IL-002,003,009 |
+
+No migration or hook was changed. The build must re-run this mapping column-by-column after migrations and code exist.

--- a/.agent-admin/evidence/table-pathway/w4-2-20260812.md
+++ b/.agent-admin/evidence/table-pathway/w4-2-20260812.md
@@ -1,0 +1,16 @@
+# Table-Pathway RED Evidence — W4.2 Persistent Invitation Lifecycle
+
+Date: 2026-08-12  
+Live project: `ooujszdvncwijbuzpjfp` (read-only inspection)
+
+| Table / storage | Current pathway | RED gap | Required closure evidence |
+|---|---|---|---|
+| `course_invitations` | Admin server action creates pending record with token hash | no approved send/revoke/resend/idempotency pathway | migration, service tests, RLS audit |
+| `course_invitation_events` | creation event recorded | RLS enabled with no policy; no full lifecycle events | policy proof + create/send/accept/revoke/resend tests |
+| `profiles` | self/admin profile policies and audit triggers | no onboarding completion/national-ID protection | migration, profile service, masked-projection tests |
+| `course_enrolments` | read policies and existing status records | redemption is not idempotent lifecycle action | transaction/service test and event proof |
+| `course_enrolment_events` | existing enrolment history | invitation redemption event absent | audit/event test |
+| `file_metadata` + `alp-private-files` | private bucket, ownership-oriented policies | CV onboarding purpose/metadata flow absent | storage-policy and upload tests |
+| `audit_events` | general audit store | lifecycle event taxonomy/evidence incomplete | audit tests/retention projection |
+
+All rows remain RED until the table-pathway inventory names migration, source consumer, policy and test evidence after build.

--- a/.github/workflows/alp-invitation-lifecycle-red.yml
+++ b/.github/workflows/alp-invitation-lifecycle-red.yml
@@ -1,0 +1,22 @@
+name: ALP Invitation Lifecycle Correct RED
+
+on:
+  pull_request:
+    paths:
+      - "tests/qa-to-red/alp/w4-2-invitation-lifecycle-red.spec.ts"
+      - "scripts/verify-invitation-lifecycle-red.mjs"
+      - "modules/ALP/**"
+      - "package.json"
+  workflow_dispatch:
+
+jobs:
+  correct-red:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run test:alp:invitation-lifecycle:red

--- a/modules/ALP/10-builder-appointment/addenda/20260812-w4-2-invitation-lifecycle-builder-appointment.md
+++ b/modules/ALP/10-builder-appointment/addenda/20260812-w4-2-invitation-lifecycle-builder-appointment.md
@@ -1,0 +1,21 @@
+# Builder Appointment — W4.2 Persistent Invitation Lifecycle
+
+Appointment ID: `APPT-ALP-W4.2-IL-001`  
+Builder Candidate: `BC-ALP-W4.2-IL-001`  
+Date: 2026-08-12
+
+## Authority
+The product owner authorised progression after PR #105 prebuild and the accepted correct-RED baseline in CI run 31611852576.
+
+## Frozen scope
+Implement only the W4.2 lifecycle: secure invitation create/send/revoke/resend; accept-to-onboarding; profile explanation/completion and private CV; protected national identity handling; idempotent enrolment redemption; audited, governed import execution; associated Supabase migrations/RLS/Storage/registered server functions.
+
+## Mandatory controls
+- Start from the RED tests; build them to GREEN without weakening assertions.
+- Resolve the RLS/security baseline blockers recorded in the RED evidence.
+- No payment, assessment, certificate generation, AI integration, unrelated media/content branch work, or production deployment.
+- No test learner, invitation or email send until the preview implementation passes automated checks and the product owner nominates the controlled learner.
+- File schema-to-hook, table-pathway, RLS audit, CI/preview and browser evidence before review.
+
+## Completion gate
+One controlled learner completes: invite → delivery → accept → onboarding/profile/CV → enrolment → learner access.

--- a/modules/ALP/11-build/evidence/20260812-W4-2-invitation-lifecycle-red-baseline.md
+++ b/modules/ALP/11-build/evidence/20260812-W4-2-invitation-lifecycle-red-baseline.md
@@ -1,0 +1,30 @@
+# W4.2 Persistent Invitation Lifecycle — RED Baseline Evidence
+
+Date: 2026-08-12  
+Baseline: main merge commit `22d9f0cd5ccfa488f544f7d07ebb2fa3317c1c41`
+
+## Read-only live inspection
+
+- Project: `apgi-learning-portal` / `ooujszdvncwijbuzpjfp`, status ACTIVE_HEALTHY.
+- Existing foundations: `profiles`, `course_invitations`, `course_invitation_events`, `course_enrolments`, `course_enrolment_events`, `audit_events`, `file_metadata`, and private `alp-private-files` Storage.
+- Existing creation action hashes a random invitation token and writes a creation event. Existing acceptance redirects directly to `/learn/:courseId`.
+- No Edge Functions are deployed for this lifecycle.
+- No migration exists for persistent onboarding/national-ID protection or dedicated CV policy.
+- Auth logs show email/password sign-in working. Deployment work must correct the deprecated GoTrue group configuration and enable leaked-password protection.
+- Supabase Security Advisor reports invitation tables with RLS but no policies, and publicly executable SECURITY DEFINER functions. These are build blockers for the persistent lifecycle; no live change was made in this RED phase.
+
+## Correct RED classification
+
+| QA IDs | Result | Classification |
+|---|---|---|
+| QA-IL-001 | Fails: create action lacks revoke/resend lifecycle | Intended missing capability |
+| QA-IL-002 | Fails: persistent lifecycle migration absent | Intended missing capability |
+| QA-IL-003 | Fails: no send/idempotency/failure workflow | Intended missing capability |
+| QA-IL-004 | Fails: acceptance routes directly to learning, not onboarding | Intended missing capability |
+| QA-IL-005 | Fails: grouped route lacks explicit lifecycle failure handling | Intended missing capability |
+| QA-IL-006..008 | Fail: no onboarding/profile protection/CV lifecycle implementation | Intended missing capability |
+| QA-IL-009 | Fails: no idempotent redemption service | Intended missing capability |
+| QA-IL-010 | Fails: no governed import execution service | Intended missing capability |
+| QA-IL-011 | Passes: AMC coverage manifest exists | Expected prebuild control |
+
+No accidental test/setup defect is accepted: the route assertion targets the actual grouped route, and all expected failures map to absent product capabilities. The CI harness must reproduce this result before builder appointment.

--- a/modules/ALP/BUILD_PROGRESS_TRACKER.md
+++ b/modules/ALP/BUILD_PROGRESS_TRACKER.md
@@ -2,12 +2,12 @@
 
 **Module**: ALP (APGI Learning Portal)  
 **Module Slug**: ALP  
-**Last Updated**: 2026-08-12 (Invitation Lifecycle prebuild)
+**Last Updated**: 2026-08-12 (Invitation Lifecycle RED accepted / builder appointed)
 **Updated By**: PR #104 merge reconciliation and product-owner authenticated smoke evidence
 > **Classification**: ACTIVE — BATCH 3 STABILISATION RELEASED; W4.2 LEARNER MANAGEMENT EXPERIENCE MERGED (DRAFT-ONLY)
 > **Repository**: APGI-cmy/Training  
 > **Current Workstream**: W4.2 Persistent Invitation Lifecycle: Supabase-backed invitation → onboarding → enrolment → learner access
-> **Next Required Action**: Execute and accept correct QA-to-Red for the frozen invitation lifecycle, then appoint a builder. No implementation, database migration, provider configuration or invitation send is authorised yet.
+> **Next Required Action**: Builder implements the frozen invitation lifecycle to GREEN, resolves recorded RLS/Auth security blockers, and files exact-head proof. No controlled learner or invitation send is authorised until preview readiness.
 
 ---
 
@@ -28,6 +28,10 @@
 | Batch 3 Lane A | Released stabilisation scope; production Git deployment smoke-tested | PR #102 merged at `312e551`; 2026-08 production reconciliation |
 | Invitation delivery preflight | CS2 authorised as separate no-send lane | No provider, secret or send implementation authorised |
 | W4.2 Learner Management Experience | Merged; safe draft/read-only workflow accepted | PR #104 merged a58579f; exact-head CI/Vercel PASS and authenticated no-write smoke |
+
+### W4.2 Persistent Invitation Lifecycle — correct RED accepted / builder appointed 2026-08-12
+
+Dedicated workflow run `31611852576` reproduced the expected RED: QA-IL-001..010 fail solely for the declared missing persistent lifecycle capabilities, while QA-IL-011 verifies the AMC manifest. Schema-to-hook, table-pathway and RLS RED evidence is filed at `.agent-admin/evidence/*/w4-2-20260812.md`. Security Advisor findings are retained as mandatory build remediation: invitation-table policies, exposed SECURITY DEFINER execution, leaked-password protection and deprecated GoTrue group configuration. Builder `BC-ALP-W4.2-IL-001` is appointed under `APPT-ALP-W4.2-IL-001` for the frozen scope only. No test learner is nominated yet.
 
 ### W4.2 Persistent Invitation Lifecycle — prebuild filed 2026-08-12
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:alp:red": "vitest run tests/qa-to-red/alp",
     "test:alp:w4-2": "vitest run tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts tests/qa-to-red/alp/w4-2-migration-security.spec.ts tests/qa-to-red/alp/w4-2-browser-repair.spec.ts tests/qa-to-red/alp/batch3-stabilisation-red.spec.ts",
     "test:alp:lm": "vitest run tests/qa-to-red/alp/w4-2-learner-management.spec.ts",
+    "test:alp:invitation-lifecycle:red": "node scripts/verify-invitation-lifecycle-red.mjs",
     "test:alp:batch3": "vitest run tests/qa-to-red/alp/batch3-stabilisation-red.spec.ts",
     "test:alp:w4-2:red": "vitest run tests/qa-to-red/alp/w4-2-enrolment-catalogue-red.spec.ts",
     "test:alp:red:static": "vitest run tests/qa-to-red/alp/governance-artifacts.spec.ts tests/qa-to-red/alp/architecture-inventory.spec.ts",

--- a/scripts/verify-invitation-lifecycle-red.mjs
+++ b/scripts/verify-invitation-lifecycle-red.mjs
@@ -1,0 +1,24 @@
+import { spawnSync } from "node:child_process";
+
+const result = spawnSync("npx", ["vitest", "run", "tests/qa-to-red/alp/w4-2-invitation-lifecycle-red.spec.ts"], {
+  encoding: "utf8",
+  shell: process.platform === "win32"
+});
+const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+process.stdout.write(output);
+
+if (result.status === 0) {
+  console.error("RED acceptance failed: lifecycle suite unexpectedly passed.");
+  process.exit(1);
+}
+const required = ["QA-IL-001", "QA-IL-002", "QA-IL-003", "QA-IL-004", "QA-IL-005", "QA-IL-006", "QA-IL-007", "QA-IL-008", "QA-IL-009", "QA-IL-010"];
+const missing = required.filter((id) => !output.includes(id));
+if (missing.length) {
+  console.error(`RED acceptance failed: expected lifecycle failures were not observed: ${missing.join(", ")}`);
+  process.exit(1);
+}
+if (!output.includes("QA-IL-011")) {
+  console.error("RED acceptance failed: AMC manifest check did not execute.");
+  process.exit(1);
+}
+console.log("Correct RED accepted: QA-IL-001..010 fail for absent persistent lifecycle capabilities; QA-IL-011 executes against the filed manifest.");


### PR DESCRIPTION
## Purpose
Records the read-only live Supabase inspection and runs the full W4.2 invitation lifecycle QA-to-Red suite through a CI harness.

## Scope
- No Supabase migration, RLS change, Storage change, invitation send, account creation, enrolment mutation or production deployment.
- Expected RED: QA-IL-001..010 fail only because persistent lifecycle capabilities are not built; QA-IL-011 validates the AMC manifest.

## Evidence
- schema-to-hook, table-pathway and RLS RED evidence will be added after the CI baseline is verified.
- Security Advisor findings are recorded as build-blocking remediation requirements.

## Next gate
If CI confirms correct RED, appoint the builder for the frozen build-to-green scope. Do not appoint a test learner until implementation is preview-ready for the controlled end-to-end test.